### PR TITLE
Fix crash when displaying post changelog page

### DIFF
--- a/templates/cranefly/threads/changelog.html
+++ b/templates/cranefly/threads/changelog.html
@@ -1,7 +1,7 @@
 {% extends "cranefly/layout.html" %}
 {% import "cranefly/macros.html" as macros with context %}
 
-{% block title %}{{ macros.page_title(title=(_("Post #%(post)s Changelog") % {'post': post.pk}),parent=thread.name) }}{% endblock %}
+{% block title %}{{ macros.page_title(title=(_("Post #%(post)s Changelog", post=post.pk)),parent=thread.name) }}{% endblock %}
 
 {% block breadcrumb %}{{ super() }} <span class="divider"><i class="icon-chevron-right"></i></span></li>
 {{ macros.parents_list(parents) }}

--- a/templates/cranefly/threads/changelog_diff.html
+++ b/templates/cranefly/threads/changelog_diff.html
@@ -1,7 +1,7 @@
 {% extends "cranefly/layout.html" %}
 {% import "cranefly/macros.html" as macros with context %}
 
-{% block title %}{{ macros.page_title(title=(_("Post #%(post)s Changelog") % {'post': post.pk}),parent=thread.name) }}{% endblock %}
+{% block title %}{{ macros.page_title(title=(_("Post #%(post)s Changelog", post=post.pk)),parent=thread.name) }}{% endblock %}
 
 {% block breadcrumb %}{{ super() }} <span class="divider"><i class="icon-chevron-right"></i></span></li>
 {{ macros.parents_list(parents) }}


### PR DESCRIPTION
Previously, you were getting a KeyError when the changelog template file was parsed. This commit fixes the syntax, so the page is displayed correctly.
(This also should not break translations, but I haven't done testing for that)
