### PR TITLE
MISAGO_BLEACH_CALLBACKS setting instead bleach.linkify defaults

### DIFF
--- a/docs/settings/Core.md
+++ b/docs/settings/Core.md
@@ -87,6 +87,11 @@ It's impossible to regenerate user avatars store for existing avatars. Misago co
 This path to image file that Misago should use as blank avatar.
 
 
+## `MISAGO_BLEACH_CALLBACKS`
+
+Custom callbacks for `bleach` to customize automatic links substitution with `bleach.linkify`.
+
+
 ## `MISAGO_COMPACT_DATE_FORMAT_DAY_MONTH`
 
 Date format used by Misago `compact_date` filter for dates in this year.

--- a/misago/conf/defaults.py
+++ b/misago/conf/defaults.py
@@ -29,6 +29,11 @@ MISAGO_ACL_EXTENSIONS = [
 MISAGO_MARKUP_EXTENSIONS = []
 
 
+# Bleach callbacks for linkifying paragraphs
+
+MISAGO_BLEACH_CALLBACKS = []
+
+
 # Custom post validators
 
 MISAGO_POST_VALIDATORS = []
@@ -37,11 +42,6 @@ MISAGO_POST_VALIDATORS = []
 # Post search filters
 
 MISAGO_POST_SEARCH_FILTERS = []
-
-
-# Bleach callbacks for linkifying paragraphs
-
-MISAGO_BLEACH_CALLBACKS = []
 
 
 # Posting middlewares

--- a/misago/conf/defaults.py
+++ b/misago/conf/defaults.py
@@ -39,6 +39,11 @@ MISAGO_POST_VALIDATORS = []
 MISAGO_POST_SEARCH_FILTERS = []
 
 
+# Bleach callbacks for linkifying paragraphs
+
+MISAGO_BLEACH_CALLBACKS = []
+
+
 # Posting middlewares
 # https://misago.readthedocs.io/en/latest/developers/posting_process.html
 

--- a/misago/markup/parser.py
+++ b/misago/markup/parser.py
@@ -12,6 +12,8 @@ from django.http import Http404
 from django.urls import resolve
 from django.utils import six
 
+from misago.conf import settings
+
 from .bbcode import blocks, inline
 from .md.shortimgs import ShortImagesExtension
 from .md.striketrough import StriketroughExtension
@@ -152,6 +154,7 @@ def md_factory(allow_links=True, allow_images=True, allow_blocks=True):
 def linkify_paragraphs(result):
     result['parsed_text'] = bleach.linkify(
         result['parsed_text'],
+        callbacks=getattr(settings, "MISAGO_BLEACH_CALLBACKS", []),
         skip_tags=['a', 'code', 'pre'],
         parse_email=True,
     )

--- a/misago/markup/parser.py
+++ b/misago/markup/parser.py
@@ -154,7 +154,7 @@ def md_factory(allow_links=True, allow_images=True, allow_blocks=True):
 def linkify_paragraphs(result):
     result['parsed_text'] = bleach.linkify(
         result['parsed_text'],
-        callbacks=getattr(settings, "MISAGO_BLEACH_CALLBACKS", []),
+        callbacks=settings.MISAGO_BLEACH_CALLBACKS,
         skip_tags=['a', 'code', 'pre'],
         parse_email=True,
     )

--- a/misago/markup/tests/test_parser.py
+++ b/misago/markup/tests/test_parser.py
@@ -192,7 +192,7 @@ Lorem ipsum: http://test.com
 """.strip()
 
         expected_result = """
-<p>Lorem ipsum: <a href="/" rel="nofollow">test.com</a></p>
+<p>Lorem ipsum: <a href="/">test.com</a></p>
 """.strip()
 
         result = parse(test_text, MockRequest(), MockPoster(), minify=True)
@@ -208,7 +208,7 @@ Lorem ipsum: test.com
 """.strip()
 
         expected_result = """
-<p>Lorem ipsum: <a href="/" rel="nofollow">test.com</a></p>
+<p>Lorem ipsum: <a href="/">test.com</a></p>
 """.strip()
 
         result = parse(test_text, MockRequest(), MockPoster(), minify=True)
@@ -224,7 +224,7 @@ Lorem ipsum: http://test.com/somewhere-something/
 """.strip()
 
         expected_result = """
-<p>Lorem ipsum: <a href="/somewhere-something/" rel="nofollow">test.com/somewhere-something/</a></p>
+<p>Lorem ipsum: <a href="/somewhere-something/">test.com/somewhere-something/</a></p>
 """.strip()
 
         result = parse(test_text, MockRequest(), MockPoster(), minify=True)


### PR DESCRIPTION
Add `MISAGO_BLEACH_CALLBACKS` setting to customize linkify behavior, as well as removing `rel=nofollow` from bleach callbacks, because this add in clean_links (and only for external links).