### PR TITLE
Update editor's index.js to fix a typo in an import

### DIFF
--- a/frontend/src/components/editor/index.js
+++ b/frontend/src/components/editor/index.js
@@ -9,7 +9,7 @@ import Striketrough from './actions/striketrough';
 import Strong from './actions/strong';
 import Quote from './actions/quote';
 import AttachmentsEditor from './attachments';
-import Upload from './attachments/upload-button/';
+import Upload from './attachments/upload-button';
 import MarkupPreview from './markup-preview';
 import * as textUtils from './textutils';
 import Button from 'misago/components/button';


### PR DESCRIPTION
There's a typo in the editor's index.js file when importing the upload-button. It's a file and not a directory.