### PR TITLE
Minor docker setup cleanup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
     build: .
     command: python manage.py runserver 0.0.0.0:8000
     environment:
+      # Name of development project
+      - PROJECT_NAME=devproject
       # Postgres
       - POSTGRES_USER=misago
       - POSTGRES_PASSWORD=misago

--- a/extras/createdevproject.py
+++ b/extras/createdevproject.py
@@ -12,7 +12,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def main():
-    project_name = 'devproject'
+    project_name = os.environ['PROJECT_NAME']
 
     # Allow for overriding project name
     if len(sys.argv) > 1:

--- a/extras/createsuperuser.py
+++ b/extras/createsuperuser.py
@@ -5,7 +5,7 @@ Create superuser for the devproject
 import os
 import django
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'devproject.settings'
+os.environ['DJANGO_SETTINGS_MODULE'] = '{}.settings'.format(os.environ['PROJECT_NAME'])
 django.setup()
 
 from django.contrib.auth import get_user_model

--- a/initdev
+++ b/initdev
@@ -3,7 +3,7 @@
 python setup.py develop
 
 # Create new project
-python extras/createdevproject.py devproject /srv/misago
+python extras/createdevproject.py $PROJECT_NAME /srv/misago
 
 # Clean up unnecessary project files
 rm -rf theme


### PR DESCRIPTION
Define devproject name only in compose. This is better than hardcoding it all around the place.