### PR TITLE
Fix legal links missing in footer

### DIFF
--- a/misago/templates/misago/footer.html
+++ b/misago/templates/misago/footer.html
@@ -10,21 +10,21 @@
         </p>
       </noscript>
 
-      {% if misago_settings.terms_of_service or misago_settings.terms_of_service_link or misago_settings.privacy_policy or misago_settings.privacy_policy_link or misago_settings.forum_footnote %}
+      {% if TERMS_OF_SERVICE_URL or PRIVACY_POLICY_URL or misago_settings.forum_footnote %}
         <ul class="list-inline footer-nav">
         {% if misago_settings.forum_footnote %}
           <li class="site-footnote">
             {{ misago_settings.forum_footnote }}
           </li>
         {% endif %}
-        {% if misago_settings.terms_of_service or misago_settings.terms_of_service_link %}
+        {% if TERMS_OF_SERVICE_URL %}
           <li>
-            <a href="{% url 'misago:terms-of-service' %}">{% trans "Terms of service" %}</a>
+            <a href="{{ TERMS_OF_SERVICE_URL }}">{% trans "Terms of service" %}</a>
           </li>
         {% endif %}
-        {% if misago_settings.privacy_policy or misago_settings.privacy_policy_link %}
+        {% if PRIVACY_POLICY_URL %}
           <li>
-            <a href="{% url 'misago:privacy-policy' %}">{% trans "Privacy policy" %}</a>
+            <a href="{{ PRIVACY_POLICY_URL }}">{% trans "Privacy policy" %}</a>
           </li>
         {% endif %}
         </ul>


### PR DESCRIPTION
This updates footer template to display legal links.