### PR TITLE
Always display debug toolbar in dev project

### DIFF
--- a/misago/bin/misago-start-devproject.py
+++ b/misago/bin/misago-start-devproject.py
@@ -36,7 +36,18 @@ def fill_in_settings(f):
         s = s.replace("'HOST': 'localhost',", "'HOST': os.environ.get('POSTGRES_HOST'),")
 
         # Specify console backend for email
-        s += "\nEMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'\n"
+        s += "\n# Set dev instance to send e-mails to console"
+        s += "\n"
+        s += "\nEMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'"
+        s += "\n"
+
+        # Tie Debug Toolbar visibility to env variable
+        s += "\n# Display debug toolbar if IN_MISAGO_DOCKER enviroment var is set to \"1\""
+        s += "\n"
+        s += "\nDEBUG_TOOLBAR_CONFIG = {"
+        s += "\n    'SHOW_TOOLBAR_CALLBACK': 'misago.conf.debugtoolbar.enable_debug_toolbar'"
+        s += "\n}"
+        s += "\n"
 
         # Empty the contents of STATICFILES_DIRS (STATICFILES_DIRS = [])
         pos = s.find('STATICFILES_DIRS')

--- a/misago/conf/debugtoolbar.py
+++ b/misago/conf/debugtoolbar.py
@@ -1,0 +1,5 @@
+import os
+
+
+def enable_debug_toolbar(_):
+    return os.environ.get('IN_MISAGO_DOCKER', '').lower() == "1"


### PR DESCRIPTION
This PR makes `misago-start-devproject` include setting forcing debug-toolbar to always be displayed when Misago is running inside dev docker.

Fixes #1051