### PR TITLE
Fix version check in the admin

### DIFF
--- a/misago/templates/misago/admin/index.html
+++ b/misago/templates/misago/admin/index.html
@@ -56,7 +56,6 @@
           <tr>
             <th colspan="2">
               <h4>
-                <span class="fa fa-github"></span>
                 {% trans "Misago version" %}
               </h4>
             </th>

--- a/misago/templates/misago/admin/index.html
+++ b/misago/templates/misago/admin/index.html
@@ -65,17 +65,16 @@
         <tbody>
           <tr>
             <td class="text-center">
-              {% if allow_version_check %}
-                {% if version_check %}
+              {% if version_check %}
                 <p class="lead text-{% if version_check.is_error %}danger{% else %}success{% endif %}">
                   {% if version_check.is_error %}
-                  <span class="fa fa-times fa-lg fa-fw"></span>
+                    <span class="fa fa-times fa-lg fa-fw"></span>
                   {% else %}
-                  <span class="fa fa-check fa-lg fa-fw"></span>
+                    <span class="fa fa-check fa-lg fa-fw"></span>
                   {% endif %}
                   {{ version_check.message }}
                 </p>
-                {% else %}
+              {% else %}
                 <form method="POST">
                   {% csrf_token %}
                   <button type="submit" class="btn btn-default">
@@ -83,11 +82,6 @@
                     <span class="name">{% trans "Check version" %}</span>
                   </button>
                 </form>
-                {% endif %}
-              {% else %}
-                <p class="lead">
-                  {% trans 'This feature requires "packaging" python module.' %}
-                </p>
               {% endif %}
             </td>
           </tr>


### PR DESCRIPTION
This PR duct-tapes version check in Misago admin to work using PyPI.org api, and doesn't require  `packaging` module because it only compares version string for equality with latest release's version.

Fixes #1091 #993