### PR TITLE
Fix script name passed to startproject execution in misago.core.setup

### DIFF
--- a/misago/core/setup.py
+++ b/misago/core/setup.py
@@ -50,7 +50,7 @@ def start_misago_project():
     project_name = validate_project_name(parser, args[0])
 
     argv = [
-        'start-misago.py', 'startproject', project_name, dir,
+        'misago-start.py', 'startproject', project_name, dir,
         '--template=%s' % get_misago_project_template()
     ]
 

--- a/misago/core/setup.py
+++ b/misago/core/setup.py
@@ -43,14 +43,14 @@ def start_misago_project():
     if len(args) < 1:
         parser.error("project_name must be specified")
 
-    dir = None
+    directory = None
     if len(args) == 2:
-        dir = args[1]
+        directory = args[1]
 
     project_name = validate_project_name(parser, args[0])
 
     argv = [
-        'misago-start.py', 'startproject', project_name, dir,
+        'misago-start.py', 'startproject', project_name, directory,
         '--template=%s' % get_misago_project_template()
     ]
 


### PR DESCRIPTION
This PR changes `start-misago.py` to `misago-start.py` in `misago.core.setup.start_misago_project`.

This value is used by `execute_from_command_line` as script/program name, and looks like its only passed to possible help and error messages, so invalid didn't break any logic really.

Fixes #1111 