### PR TITLE
Tweak test accuracy and revert ranking algo because new one was Dj2 only

### DIFF
--- a/misago/users/activepostersranking.py
+++ b/misago/users/activepostersranking.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
-from django.db.models import Count, Q
+from django.db.models import Count
 from django.utils import timezone
 
 from misago.categories.models import Category
 from misago.conf import settings
-from misago.threads.models import Post
 
 from .models import ActivityRanking
 
@@ -38,12 +37,15 @@ def build_active_posters_ranking():
     for category in Category.objects.all_categories():
         ranked_categories.append(category.pk)
 
-    ranked_posts = Q(posted_on__gte=tracked_since) & Q(category__in=ranked_categories)
-
     queryset = (
         UserModel.objects
-        .annotate(score=Count('post', filter=ranked_posts))
-        .filter(is_active=True, score__gt=0)
+        .filter(
+            is_active=True,
+            post__posted_on__gte=tracked_since,
+            post__category__in=ranked_categories,	
+        )
+        .annotate(score=Count('post'))
+        .filter(score__gt=0)
         .order_by('-score')
     )[:settings.MISAGO_RANKING_SIZE]
 

--- a/misago/users/tests/test_activepostersranking.py
+++ b/misago/users/tests/test_activepostersranking.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 from misago.categories.models import Category
 from misago.core import threadstore
@@ -35,9 +38,21 @@ class TestActivePostersRanking(AuthenticatedUserTestCase):
         self.assertEqual(empty_ranking['users'], [])
         self.assertEqual(empty_ranking['users_count'], 0)
 
-        # other user
+        # other user that will be posting
         other_user = UserModel.objects.create_user("OtherUser", "other@user.com", "pass123")
 
+        # lurker user that won't post anything
+        UserModel.objects.create_user("Lurker", "lurker@user.com", "pass123")
+
+        # unranked user that posted something 400 days ago
+        unranked_user = UserModel.objects.create_user(
+            "UnrankedUser", "unranked@user.com", "pass123"
+        )
+
+        started_on = timezone.now() - timedelta(days=400)
+        post_thread(self.category, poster=unranked_user, started_on=started_on)
+
+        # Start testing scenarios
         post_thread(self.category, poster=other_user)
 
         build_active_posters_ranking()


### PR DESCRIPTION
This PR reverts users activity ranking implementation to old one, because new one was using features not present in Django 2 (but not raising errors in Django 1.11).

Our (messy) test case has also been tweaked to test that users that posted outside of ranked period don't show on ranking.

Fixes #1110 