### PR TITLE
Revert most of code to old-style format

### DIFF
--- a/misago/core/context_processors.py
+++ b/misago/core/context_processors.py
@@ -28,7 +28,7 @@ def current_link(request):
     url_name = request.resolver_match.url_name
     if request.resolver_match.namespaces:
         namespaces = ':'.join(request.resolver_match.namespaces)
-        link_name = '{}:{}'.format(namespaces, url_name)
+        link_name = '%s:%s' % (namespaces, url_name)
     else:
         link_name = url_name
 

--- a/misago/core/momentjs.py
+++ b/misago/core/momentjs.py
@@ -1,13 +1,13 @@
 from misago.conf import settings
 
 
-MOMENT_STATIC_PATH = 'misago/momentjs/{}.js'
+MOMENT_STATIC_PATH = 'misago/momentjs/%s.js'
 
 
 def get_locale_url(language):
     clean_language = clean_language_name(language)
     if clean_language:
-        return MOMENT_STATIC_PATH.format(clean_language)
+        return MOMENT_STATIC_PATH % clean_language
 
     return None
 

--- a/misago/core/pgutils.py
+++ b/misago/core/pgutils.py
@@ -19,7 +19,7 @@ class PgPartialIndex(Index):
         column_names = sorted(self.where.keys())
         where_items = []
         for key in sorted(self.where.keys()):
-            where_items.append('{}:{}'.format(key, repr(self.where[key])))
+            where_items.append('%s:%s' % (key, repr(self.where[key])))
 
         # The length of the parts of the name is based on the default max
         # length of 30 characters.
@@ -46,8 +46,8 @@ class PgPartialIndex(Index):
                 ]))
             return '<%(name)s: fields=%(fields)s, where=%(where)s>' % {
                 'name': self.__class__.__name__,
-                'fields': "'{}'".format(', '.join(self.fields)),
-                'where': "'{}'".format(', '.join(where_items)),
+                'fields': "'%s'" % (', '.join(self.fields)),
+                'where': "'%s'" % (', '.join(where_items)),
             }
         else:
             return super().__repr__()
@@ -88,10 +88,9 @@ class PgPartialIndex(Index):
                 compr = '='
 
             column = model._meta.get_field(field_name).column
-            clauses.append('{} {} {}'.format(
-                quote_name(column), compr, quote_value(condition)))
+            clauses.append('%s %s %s' % (quote_name(column), compr, quote_value(condition)))
         # sort clauses for their order to be determined and testable
-        return ' WHERE {}'.format(' AND '.join(sorted(clauses)))
+        return ' WHERE %s' % (' AND '.join(sorted(clauses)))
 
 
 def chunk_queryset(queryset, chunk_size=20):

--- a/misago/core/serializers.py
+++ b/misago/core/serializers.py
@@ -2,7 +2,7 @@ class MutableFields(object):
     @classmethod
     def subset_fields(cls, *fields):
         fields_in_name = [f.title().replace('_', '') for f in fields]
-        name = '{}{}Subset'.format(cls.__name__, ''.join(fields_in_name)[:100])
+        name = '%s%sSubset' % (cls.__name__, ''.join(fields_in_name)[:100])
 
         class Meta(cls.Meta):
             pass
@@ -19,7 +19,7 @@ class MutableFields(object):
                 final_fields.append(field)
 
         fields_in_name = [f.title().replace('_', '') for f in final_fields]
-        name = '{}{}Subset'.format(cls.__name__, ''.join(fields_in_name)[:100])
+        name = '%s%sSubset' % (cls.__name__, ''.join(fields_in_name)[:100])
 
         class Meta(cls.Meta):
             pass
@@ -36,7 +36,7 @@ class MutableFields(object):
                 final_fields.append(field)
 
         fields_in_name = [f.title().replace('_', '') for f in final_fields]
-        name = '{}{}Subset'.format(cls.__name__, ''.join(fields_in_name)[:100])
+        name = '%s%sSubset' % (cls.__name__, ''.join(fields_in_name)[:100])
 
         class Meta(cls.Meta):
             pass

--- a/misago/core/templatetags/misago_absoluteurl.py
+++ b/misago/core/templatetags/misago_absoluteurl.py
@@ -20,4 +20,4 @@ def absoluteurl(url_or_name, *args, **kwargs):
         if not url_or_name.startswith('/'):
             return url_or_name
     
-    return '{}{}'.format(absolute_url_prefix, url_or_name)
+    return '%s%s' % (absolute_url_prefix, url_or_name)

--- a/misago/core/tests/test_jsi18n.py
+++ b/misago/core/tests/test_jsi18n.py
@@ -13,7 +13,7 @@ LOCALES_DIR = os.path.join(MISAGO_DIR, 'locale')
 class JsI18nUrlTests(TestCase):
     def test_url_cache_buster(self):
         """js i18n catalog link has cachebuster with lang code"""
-        url = '{}?{}'.format(reverse('django-i18n'), settings.LANGUAGE_CODE)
+        url = '%s?%s' % (reverse('django-i18n'), settings.LANGUAGE_CODE)
 
         response = self.client.get(reverse('misago:index'))
         self.assertContains(response, url)
@@ -33,4 +33,4 @@ class JsI18nUrlTests(TestCase):
                 failed_languages.append(language)
 
         if failed_languages:
-            self.fail("JS catalog failed for languages: {}".format(', '.join(failed_languages)))
+            self.fail("JS catalog failed for languages: %s" % (', '.join(failed_languages)))

--- a/misago/legal/views/legal.py
+++ b/misago/legal/views/legal.py
@@ -12,7 +12,7 @@ def legal_view(request, agreement_type):
     if agreement.link:
         return redirect(agreement.link)
 
-    template_name = 'misago/{}.html'.format(agreement_type)
+    template_name = 'misago/%s.html' % agreement_type
     agreement_text = get_parsed_agreement_text(request, agreement)
 
     return render(

--- a/misago/markup/bbcode/blocks.py
+++ b/misago/markup/bbcode/blocks.py
@@ -52,16 +52,16 @@ class QuotePreprocessor(Preprocessor):
 
     def replace(self, matchobj):
         text = matchobj.group('text')
-        return '\n\n{}\n\n{}\n\n{}\n\n'.format(QUOTE_START, text, QUOTE_END)
+        return '\n\n%s\n\n%s\n\n%s\n\n' % (QUOTE_START, text, QUOTE_END)
 
     def replace_titled(self, matchobj):
         title = matchobj.group('title').strip()
         text = matchobj.group('text')
 
         if title:
-            return '\n\n{}{}\n\n{}\n\n{}\n\n'.format(QUOTE_START, title, text, QUOTE_END)
+            return '\n\n%s%s\n\n%s\n\n%s\n\n' % (QUOTE_START, title, text, QUOTE_END)
         else:
-            return '\n\n{}\n\n{}\n\n{}\n\n'.format(QUOTE_START, text, QUOTE_END)
+            return '\n\n%s\n\n%s\n\n%s\n\n' % (QUOTE_START, text, QUOTE_END)
 
 
 class QuoteBlockProcessor(BlockProcessor):

--- a/misago/markup/finalise.py
+++ b/misago/markup/finalise.py
@@ -20,4 +20,4 @@ def replace_headers(matchobj):
         quote_title = _("%(title)s has written:") % {'title': title}
     else:
         quote_title = _("Quoted message:")
-    return '<div class="quote-heading">{}</div>'.format(quote_title)
+    return '<div class="quote-heading">%s</div>' % quote_title

--- a/misago/markup/mentions.py
+++ b/misago/markup/mentions.py
@@ -58,7 +58,7 @@ def parse_string(request, element, mentions_dict):
 
         if mentions_dict[username]:
             user = mentions_dict[username]
-            return '<a href="{}">@{}</a>'.format(user.get_absolute_url(), user.username)
+            return '<a href="%s">@%s</a>' % (user.get_absolute_url(), user.username)
         else:
             # we've failed to resolve user for username
             return matchobj.group(0)

--- a/misago/markup/parser.py
+++ b/misago/markup/parser.py
@@ -212,9 +212,9 @@ def assert_link_prefix(link):
     if link.lower().startswith('http:'):
         return link
     if link.startswith('//'):
-        return 'http:{}'.format(link)
+        return 'http:%s' % link
 
-    return 'http://{}'.format(link)
+    return 'http://%s' % link
 
 
 def clean_internal_link(link, host):
@@ -240,7 +240,7 @@ def clean_attachment_link(link, force_shva=False):
 
     if url_name in MISAGO_ATTACHMENT_VIEWS:
         if force_shva:
-            link = '{}?shva=1'.format(link)
+            link = '%s?shva=1' % link
         elif link.endswith('?shva=1'):
             link = link[:-7]
     return link

--- a/misago/markup/tests/test_mentions.py
+++ b/misago/markup/tests/test_mentions.py
@@ -11,26 +11,26 @@ class MentionsTests(AuthenticatedUserTestCase):
     def test_single_mention(self):
         """markup extension parses single mention"""
         TEST_CASES = [
-            ('<p>Hello, @{}!</p>', '<p>Hello, <a href="{}">@{}</a>!</p>'),
-            ('<h1>Hello, @{}!</h1>', '<h1>Hello, <a href="{}">@{}</a>!</h1>'),
-            ('<div>Hello, @{}!</div>', '<div>Hello, <a href="{}">@{}</a>!</div>'),
+            ('<p>Hello, @%s!</p>', '<p>Hello, <a href="%s">@%s</a>!</p>'),
+            ('<h1>Hello, @%s!</h1>', '<h1>Hello, <a href="%s">@%s</a>!</h1>'),
+            ('<div>Hello, @%s!</div>', '<div>Hello, <a href="%s">@%s</a>!</div>'),
             (
-                '<h1>Hello, <strong>@{}!</strong></h1>',
-                '<h1>Hello, <strong><a href="{}">@{}</a>!</strong></h1>'
+                '<h1>Hello, <strong>@%s!</strong></h1>',
+                '<h1>Hello, <strong><a href="%s">@%s</a>!</strong></h1>'
             ),
             (
-                '<h1>Hello, <strong>@{}</strong>!</h1>',
-                '<h1>Hello, <strong><a href="{}">@{}</a></strong>!</h1>'
+                '<h1>Hello, <strong>@%s</strong>!</h1>',
+                '<h1>Hello, <strong><a href="%s">@%s</a></strong>!</h1>'
             ),
         ]
 
         for before, after in TEST_CASES:
-            result = {'parsed_text': before.format(self.user.username), 'mentions': []}
+            result = {'parsed_text': before % self.user.username, 'mentions': []}
 
             add_mentions(MockRequest(self.user), result)
 
-            outcome = after.format(self.user.get_absolute_url(), self.user.username)
-            self.assertEqual(result['parsed_text'], outcome)
+            expected_outcome = after % (self.user.get_absolute_url(), self.user.username)
+            self.assertEqual(result['parsed_text'], expected_outcome)
             self.assertEqual(result['mentions'], [self.user])
 
     def test_invalid_mentions(self):
@@ -38,8 +38,8 @@ class MentionsTests(AuthenticatedUserTestCase):
         TEST_CASES = [
             '<p>Hello, Bob!</p>',
             '<p>Hello, @Bob!</p>',
-            '<p>Hello, <a href="/">@{}</a>!</p>'.format(self.user.username),
-            '<p>Hello, <a href="/"><b>@{}</b></a>!</p>'.format(self.user.username),
+            '<p>Hello, <a href="/">@%s</a>!</p>' % self.user.username,
+            '<p>Hello, <a href="/"><b>@%s</b></a>!</p>' % self.user.username,
         ]
 
         for markup in TEST_CASES:

--- a/misago/markup/tests/test_parser.py
+++ b/misago/markup/tests/test_parser.py
@@ -170,12 +170,12 @@ Lorem ipsum.
         user = UserModel.objects.create_user('Bob', 'bob@test.com', 'Pass123')
 
         test_text = """
-Hey there @{}, how's going?
-""".strip().format(user)
+Hey there @%s, how's going?
+""".strip() % user
 
         expected_result = """
-<p>Hey there <a href="{}">@{}</a>, how's going?</p>
-""".strip().format(user.get_absolute_url(), user)
+<p>Hey there <a href="%s">@%s</a>, how's going?</p>
+""".strip() % (user.get_absolute_url(), user)
 
         result = parse(test_text, MockRequest(user), user, minify=True)
         self.assertEqual(expected_result, result['parsed_text'])

--- a/misago/threads/anonymize.py
+++ b/misago/threads/anonymize.py
@@ -13,7 +13,7 @@ ANONYMIZABLE_EVENTS = (
 
 def anonymize_event(user, event):
     if event.event_type not in ANONYMIZABLE_EVENTS:
-        raise ValueError('event of type "{}" can\'t be ananymized'.format(event.event_type))
+        raise ValueError('event of type "%s" can\'t be ananymized' % event.event_type)
 
     event.event_context = {
         'user': {

--- a/misago/threads/management/commands/clearattachments.py
+++ b/misago/threads/management/commands/clearattachments.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             self.sync_attachments(queryset, attachments_to_sync)
 
     def sync_attachments(self, queryset, attachments_to_sync):
-        self.stdout.write("Clearing {} attachments...\n".format(attachments_to_sync))
+        self.stdout.write("Clearing %s attachments...\n" % attachments_to_sync)
 
         cleared_count = 0
         show_progress(self, cleared_count, attachments_to_sync)
@@ -40,4 +40,4 @@ class Command(BaseCommand):
             cleared_count += 1
             show_progress(self, cleared_count, attachments_to_sync, start_time)
 
-        self.stdout.write("\n\nCleared {} attachments".format(cleared_count))
+        self.stdout.write("\n\nCleared %s attachments" % cleared_count)

--- a/misago/threads/management/commands/rebuildpostssearch.py
+++ b/misago/threads/management/commands/rebuildpostssearch.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             self.rebuild_posts_search(posts_to_reindex)
 
     def rebuild_posts_search(self, posts_to_reindex):
-        self.stdout.write("Rebuilding search for {} posts...\n".format(posts_to_reindex))
+        self.stdout.write("Rebuilding search for %s posts...\n" % posts_to_reindex)
 
         rebuild_count = 0
         show_progress(self, rebuild_count, posts_to_reindex)
@@ -39,4 +39,4 @@ class Command(BaseCommand):
             rebuild_count += 1
             show_progress(self, rebuild_count, posts_to_reindex, start_time)
 
-        self.stdout.write("\n\nRebuild search for {} posts".format(rebuild_count))
+        self.stdout.write("\n\nRebuild search for %s posts" % rebuild_count)

--- a/misago/threads/management/commands/synchronizethreads.py
+++ b/misago/threads/management/commands/synchronizethreads.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             self.sync_threads(threads_to_sync)
 
     def sync_threads(self, threads_to_sync):
-        self.stdout.write("Synchronizing {} threads...\n".format(threads_to_sync))
+        self.stdout.write("Synchronizing %s threads...\n" % threads_to_sync)
 
         synchronized_count = 0
         show_progress(self, synchronized_count, threads_to_sync)
@@ -32,4 +32,4 @@ class Command(BaseCommand):
             synchronized_count += 1
             show_progress(self, synchronized_count, threads_to_sync, start_time)
 
-        self.stdout.write("\n\nSynchronized {} threads".format(synchronized_count))
+        self.stdout.write("\n\nSynchronized %s threads" % synchronized_count)

--- a/misago/threads/management/commands/updatepostschecksums.py
+++ b/misago/threads/management/commands/updatepostschecksums.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             self.update_posts_checksums(posts_to_update)
 
     def update_posts_checksums(self, posts_to_update):
-        self.stdout.write("Updating {} posts checksums...\n".format(posts_to_update))
+        self.stdout.write("Updating %s posts checksums...\n" % posts_to_update)
 
         updated_count = 0
         show_progress(self, updated_count, posts_to_update)
@@ -34,4 +34,4 @@ class Command(BaseCommand):
             updated_count += 1
             show_progress(self, updated_count, posts_to_update, start_time)
 
-        self.stdout.write("\n\nUpdated {} posts checksums".format(updated_count))
+        self.stdout.write("\n\nUpdated %s posts checksums" % updated_count)

--- a/misago/threads/mergeconflict.py
+++ b/misago/threads/mergeconflict.py
@@ -75,7 +75,7 @@ class PollMergeHandler(MergeConflictHandler):
     def get_available_resolutions(self):
         resolutions = [[0, _("Delete all polls")]]
         for poll in self.items:
-            resolutions.append([poll.id, '{} ({})'.format(poll.question, poll.thread.title)])
+            resolutions.append([poll.id, '%s (%s)' % (poll.question, poll.thread.title)])
         return resolutions
 
 
@@ -131,7 +131,7 @@ class MergeConflict(object):
     def raise_resolutions_exception(self):
         resolutions = {}
         for conflict in self._conflicts:
-            key = '{}s'.format(conflict.data_name)
+            key = '%ss' % conflict.data_name
             resolutions[key] = conflict.get_available_resolutions()
         if resolutions:
             raise ValidationError(resolutions)

--- a/misago/threads/tests/test_attachmentadmin_views.py
+++ b/misago/threads/tests/test_attachmentadmin_views.py
@@ -26,7 +26,7 @@ class AttachmentAdminViewsTests(AdminTestCase):
             uploader=self.user,
             uploader_name=self.user.username,
             uploader_slug=self.user.slug,
-            filename='testfile_{}.zip'.format(Attachment.objects.count() + 1),
+            filename='testfile_%s.zip' % (Attachment.objects.count() + 1),
             file=None,
             image=None,
             thumbnail=None,

--- a/misago/threads/tests/test_attachments_middleware.py
+++ b/misago/threads/tests/test_attachments_middleware.py
@@ -41,7 +41,7 @@ class AttachmentsMiddlewareTests(AuthenticatedUserTestCase):
             uploader=self.user if user else None,
             uploader_name=self.user.username,
             uploader_slug=self.user.slug,
-            filename='testfile_{}.zip'.format(Attachment.objects.count() + 1),
+            filename='testfile_%s.zip' % (Attachment.objects.count() + 1),
         )
 
     def test_use_this_middleware(self):

--- a/misago/threads/tests/test_clearattachments.py
+++ b/misago/threads/tests/test_clearattachments.py
@@ -39,7 +39,7 @@ class ClearAttachmentsTests(TestCase):
                 uploaded_on=cutoff,
                 uploader_name='bob',
                 uploader_slug='bob',
-                filename='testfile_{}.zip'.format(Attachment.objects.count() + 1),
+                filename='testfile_%s.zip' % (Attachment.objects.count() + 1),
             )
 
         # create 5 expired non-orphaned attachments
@@ -55,7 +55,7 @@ class ClearAttachmentsTests(TestCase):
                 post=post,
                 uploader_name='bob',
                 uploader_slug='bob',
-                filename='testfile_{}.zip'.format(Attachment.objects.count() + 1),
+                filename='testfile_%s.zip' % (Attachment.objects.count() + 1),
             )
 
         # create 5 fresh orphaned attachments
@@ -66,7 +66,7 @@ class ClearAttachmentsTests(TestCase):
                 size=1000,
                 uploader_name='bob',
                 uploader_slug='bob',
-                filename='testfile_{}.zip'.format(Attachment.objects.count() + 1),
+                filename='testfile_%s.zip' % (Attachment.objects.count() + 1),
             )
 
         command = clearattachments.Command()

--- a/misago/threads/tests/test_mergeconflict.py
+++ b/misago/threads/tests/test_mergeconflict.py
@@ -174,7 +174,7 @@ class MergeConflictTests(TestCase):
                 'polls': [['0', 'Delete all polls']] + [
                     [
                         str(thread.poll.id),
-                        '{} ({})'.format(thread.poll.question, thread.title),
+                        '%s (%s)' % (thread.poll.question, thread.title),
                     ] for thread in polls
                 ]
             })
@@ -238,7 +238,7 @@ class MergeConflictTests(TestCase):
                 'polls': [['0', 'Delete all polls']] + [
                     [
                         str(thread.poll.id),
-                        '{} ({})'.format(thread.poll.question, thread.title),
+                        '%s (%s)' % (thread.poll.question, thread.title),
                     ] for thread in polls
                 ]
             })

--- a/misago/threads/tests/test_post_mentions.py
+++ b/misago/threads/tests/test_post_mentions.py
@@ -70,7 +70,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
         """endpoint mentions author"""
         response = self.client.post(
             self.post_link, data={
-                'post': "This is test response, @{}!".format(self.user),
+                'post': "This is test response, @%s!" % self.user,
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -87,14 +87,14 @@ class PostMentionsTests(AuthenticatedUserTestCase):
         for i in range(MENTIONS_LIMIT + 5):
             users.append(
                 UserModel.objects.
-                create_user('Mention{}'.format(i), 'mention{}@bob.com'.format(i), 'pass123')
+                create_user('Mention%s' % i, 'mention%s@bob.com' % i, 'pass123')
             )
 
-        mentions = ['@{}'.format(u) for u in users]
+        mentions = ['@%s' % u for u in users]
         response = self.client.post(
             self.post_link,
             data={
-                'post': "This is test response, {}!".format(', '.join(mentions)),
+                'post': "This is test response, %s!" % (', '.join(mentions)),
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -111,7 +111,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
 
         response = self.client.post(
             self.post_link, data={
-                'post': "This is test response, @{}!".format(user_a),
+                'post': "This is test response, @%s!" % user_a,
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -133,7 +133,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
         response = self.put(
             edit_link,
             data={
-                'post': "This is test response, @{} and @{}!".format(user_a, user_b),
+                'post': "This is test response, @%s and @%s!" % (user_a, user_b),
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -145,7 +145,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
         self.override_acl()
         response = self.put(
             edit_link, data={
-                'post': "This is test response, @{}!".format(user_b),
+                'post': "This is test response, @%s!" % user_b,
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -172,7 +172,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
 
         response = self.client.post(
             self.post_link, data={
-                'post': "This is test response, @{}!".format(user_a),
+                'post': "This is test response, @%s!" % user_a,
             }
         )
         self.assertEqual(response.status_code, 200)
@@ -189,7 +189,7 @@ class PostMentionsTests(AuthenticatedUserTestCase):
         response = self.client.post(
             self.post_link,
             data={
-                'post': "This is test response, @{} and @{}!".format(user_a, user_b),
+                'post': "This is test response, @%s and @%s!" % (user_a, user_b),
             }
         )
         self.assertEqual(response.status_code, 200)

--- a/misago/threads/tests/test_privatethread_patch_api.py
+++ b/misago/threads/tests/test_privatethread_patch_api.py
@@ -152,7 +152,7 @@ class PrivateThreadAddParticipantApiTests(PrivateThreadPatchApiTestCase):
 
         for i in range(self.user.acl_cache['max_private_thread_participants']):
             user = UserModel.objects.create_user(
-                'User{}'.format(i), 'user{}@example.com'.format(i), 'Pass.123'
+                'User%s' % i, 'user%s@example.com' % i, 'Pass.123'
             )
             ThreadParticipant.objects.add_participants(self.thread, [user])
 

--- a/misago/threads/tests/test_privatethread_start_api.py
+++ b/misago/threads/tests/test_privatethread_start_api.py
@@ -140,7 +140,7 @@ class StartPrivateThreadTests(AuthenticatedUserTestCase):
         response = self.client.post(
             self.api_link,
             data={
-                'to': ['Username{}'.format(i) for i in range(50)],
+                'to': ['Username%s' % i for i in range(50)],
                 'title': "Lorem ipsum dolor met",
                 'post': "Lorem ipsum dolor.",
             }

--- a/misago/threads/tests/test_thread_merge_api.py
+++ b/misago/threads/tests/test_thread_merge_api.py
@@ -785,11 +785,11 @@ class ThreadMergeApiTests(ThreadsApiTestCase):
                     ['0', "Delete all polls"],
                     [
                         str(poll.pk),
-                        '{} ({})'.format(poll.question, poll.thread.title),
+                        '%s (%s)' % (poll.question, poll.thread.title),
                     ],
                     [
                         str(other_poll.pk),
-                        '{} ({})'.format(other_poll.question, other_poll.thread.title),
+                        '%s (%s)' % (other_poll.question, other_poll.thread.title),
                     ],
                 ]
             }

--- a/misago/threads/tests/test_thread_postedits_api.py
+++ b/misago/threads/tests/test_thread_postedits_api.py
@@ -77,17 +77,17 @@ class ThreadPostGetEditTests(ThreadPostEditsApiTestCase):
 
     def test_empty_edit_id(self):
         """api handles empty edit in querystring"""
-        response = self.client.get('{}?edit='.format(self.api_link))
+        response = self.client.get('%s?edit=' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_invalid_edit_id(self):
         """api handles invalid edit in querystring"""
-        response = self.client.get('{}?edit=dsa67d8sa68'.format(self.api_link))
+        response = self.client.get('%s?edit=dsa67d8sa68' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_nonexistant_edit_id(self):
         """api handles nonexistant edit in querystring"""
-        response = self.client.get('{}?edit=1321'.format(self.api_link))
+        response = self.client.get('%s?edit=1321' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_get_last_edit(self):
@@ -107,7 +107,7 @@ class ThreadPostGetEditTests(ThreadPostEditsApiTestCase):
         """api returns middle edit record"""
         edits = self.mock_edit_record()
 
-        response = self.client.get('{}?edit={}'.format(self.api_link, edits[1].id))
+        response = self.client.get('%s?edit=%s' % (self.api_link, edits[1].id))
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
@@ -120,7 +120,7 @@ class ThreadPostGetEditTests(ThreadPostEditsApiTestCase):
         """api returns middle edit record"""
         edits = self.mock_edit_record()
 
-        response = self.client.get('{}?edit={}'.format(self.api_link, edits[0].id))
+        response = self.client.get('%s?edit=%s' % (self.api_link, edits[0].id))
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
@@ -139,36 +139,36 @@ class ThreadPostPostEditTests(ThreadPostEditsApiTestCase):
 
     def test_empty_edit_id(self):
         """api handles empty edit in querystring"""
-        response = self.client.post('{}?edit='.format(self.api_link))
+        response = self.client.post('%s?edit=' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_invalid_edit_id(self):
         """api handles invalid edit in querystring"""
-        response = self.client.post('{}?edit=dsa67d8sa68'.format(self.api_link))
+        response = self.client.post('%s?edit=dsa67d8sa68' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_nonexistant_edit_id(self):
         """api handles nonexistant edit in querystring"""
-        response = self.client.post('{}?edit=1321'.format(self.api_link))
+        response = self.client.post('%s?edit=1321' % self.api_link)
         self.assertEqual(response.status_code, 404)
 
     def test_anonymous(self):
         """only signed in users can rever ports"""
         self.logout_user()
 
-        response = self.client.post('{}?edit={}'.format(self.api_link, self.edits[0].id))
+        response = self.client.post('%s?edit=%s' % (self.api_link, self.edits[0].id))
         self.assertEqual(response.status_code, 403)
 
     def test_no_permission(self):
         """api validates permission to revert post"""
         self.override_acl({'can_edit_posts': 0})
 
-        response = self.client.post('{}?edit=1321'.format(self.api_link))
+        response = self.client.post('%s?edit=1321' % self.api_link)
         self.assertEqual(response.status_code, 403)
 
     def test_revert_post(self):
         """api reverts post to version from before specified edit"""
-        response = self.client.post('{}?edit={}'.format(self.api_link, self.edits[0].id))
+        response = self.client.post('%s?edit=%s' % (self.api_link, self.edits[0].id))
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()

--- a/misago/threads/tests/test_thread_postmerge_api.py
+++ b/misago/threads/tests/test_thread_postmerge_api.py
@@ -436,7 +436,7 @@ class ThreadPostMergeApiTestCase(AuthenticatedUserTestCase):
             Post.objects.get(pk=post_b.pk)
 
         merged_post = Post.objects.get(pk=post_a.pk)
-        self.assertEqual(merged_post.parsed, '{}\n{}'.format(post_a.parsed, post_b.parsed))
+        self.assertEqual(merged_post.parsed, '%s\n%s' % (post_a.parsed, post_b.parsed))
 
     def test_merge_guest_posts(self):
         """api recjects attempt to merge posts made by same guest"""

--- a/misago/threads/tests/test_threads_editor_api.py
+++ b/misago/threads/tests/test_threads_editor_api.py
@@ -367,7 +367,7 @@ class ThreadReplyEditorApiTests(EditorApiTestCase):
             is_unapproved=True,
         )
 
-        response = self.client.get('{}?reply={}'.format(self.api_link, unapproved_reply.pk))
+        response = self.client.get('%s?reply=%s' % (self.api_link, unapproved_reply.pk))
         self.assertEqual(response.status_code, 404)
 
         # hidden reply can't be replied to
@@ -375,7 +375,7 @@ class ThreadReplyEditorApiTests(EditorApiTestCase):
 
         hidden_reply = testutils.reply_thread(self.thread, is_hidden=True)
 
-        response = self.client.get('{}?reply={}'.format(self.api_link, hidden_reply.pk))
+        response = self.client.get('%s?reply=%s' % (self.api_link, hidden_reply.pk))
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {
             "detail": "You can't reply to hidden posts.",
@@ -386,7 +386,7 @@ class ThreadReplyEditorApiTests(EditorApiTestCase):
         other_thread = testutils.post_thread(category=self.category)
         reply_to = testutils.reply_thread(other_thread)
 
-        response = self.client.get('{}?reply={}'.format(self.api_link, reply_to.pk))
+        response = self.client.get('%s?reply=%s' % (self.api_link, reply_to.pk))
         self.assertEqual(response.status_code, 404)
 
     def test_reply_to_event(self):
@@ -395,7 +395,7 @@ class ThreadReplyEditorApiTests(EditorApiTestCase):
 
         reply_to = testutils.reply_thread(self.thread, is_event=True)
 
-        response = self.client.get('{}?reply={}'.format(self.api_link, reply_to.pk))
+        response = self.client.get('%s?reply=%s' % (self.api_link, reply_to.pk))
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json(), {
             "detail": "You can't reply to events.",
@@ -407,7 +407,7 @@ class ThreadReplyEditorApiTests(EditorApiTestCase):
 
         reply_to = testutils.reply_thread(self.thread)
 
-        response = self.client.get('{}?reply={}'.format(self.api_link, reply_to.pk))
+        response = self.client.get('%s?reply=%s' % (self.api_link, reply_to.pk))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(

--- a/misago/threads/tests/test_threads_merge_api.py
+++ b/misago/threads/tests/test_threads_merge_api.py
@@ -1035,11 +1035,11 @@ class ThreadsMergeApiTests(ThreadsApiTestCase):
                     ['0', "Delete all polls"],
                     [
                         str(other_poll.pk),
-                        '{} ({})'.format(other_poll.question, other_poll.thread.title),
+                        '%s (%s)' % (other_poll.question, other_poll.thread.title),
                     ],
                     [
                         str(poll.pk),
-                        '{} ({})'.format(poll.question, poll.thread.title),
+                        '%s (%s)' % (poll.question, poll.thread.title),
                     ],
                 ],
             }

--- a/misago/threads/tests/test_threadslists.py
+++ b/misago/threads/tests/test_threadslists.py
@@ -161,26 +161,26 @@ class ThreadsListTestCase(AuthenticatedUserTestCase):
         return categories_acl
 
     def assertContainsThread(self, response, thread):
-        self.assertContains(response, ' href="{}"'.format(thread.get_absolute_url()))
+        self.assertContains(response, ' href="%s"' % thread.get_absolute_url())
 
     def assertNotContainsThread(self, response, thread):
-        self.assertNotContains(response, ' href="{}"'.format(thread.get_absolute_url()))
+        self.assertNotContains(response, ' href="%s"' % thread.get_absolute_url())
 
 
 class ApiTests(ThreadsListTestCase):
     def test_root_category(self):
         """its possible to access threads endpoint with category=ROOT_ID"""
-        response = self.client.get('%s?category=%s' % (self.api_link, self.root.pk, ))
+        response = self.client.get('%s?category=%s' % (self.api_link, self.root.pk))
         self.assertEqual(response.status_code, 200)
 
     def test_explicit_first_page(self):
         """its possible to access threads endpoint with explicit first page"""
-        response = self.client.get('%s?category=%s&page=1' % (self.api_link, self.root.pk, ))
+        response = self.client.get('%s?category=%s&page=1' % (self.api_link, self.root.pk))
         self.assertEqual(response.status_code, 200)
 
     def test_invalid_list_type(self):
         """api returns 404 for invalid list type"""
-        response = self.client.get('%s?category=%s&list=nope' % (self.api_link, self.root.pk, ))
+        response = self.client.get('%s?category=%s&list=nope' % (self.api_link, self.root.pk))
         self.assertEqual(response.status_code, 404)
 
 

--- a/misago/threads/tests/test_utils.py
+++ b/misago/threads/tests/test_utils.py
@@ -167,7 +167,7 @@ class MockRequest(object):
         self.host = host
 
         self.path_info = '/api/threads/123/merge/'
-        self.path = '{}{}'.format(wsgialias.rstrip('/'), self.path_info)
+        self.path = '%s%s' % (wsgialias.rstrip('/'), self.path_info)
 
     def get_host(self):
         return self.host
@@ -247,7 +247,7 @@ class GetThreadIdFromUrlTests(MisagoTestCase):
             pk = get_thread_id_from_url(case['request'], case['url'])
             self.assertEqual(
                 pk, case['pk'],
-                'get_thread_id_from_url for {} should return {}'.format(case['url'], case['pk'])
+                'get_thread_id_from_url for %(url)s should return %(pk)s' % case
             )
 
     def test_get_thread_id_from_invalid_urls(self):
@@ -301,4 +301,4 @@ class GetThreadIdFromUrlTests(MisagoTestCase):
 
         for case in TEST_CASES:
             pk = get_thread_id_from_url(case['request'], case['url'])
-            self.assertIsNone(pk, 'get_thread_id_from_url for {} should fail'.format(case['url']))
+            self.assertIsNone(pk, 'get_thread_id_from_url for %s should fail' % case['url'])

--- a/misago/threads/utils.py
+++ b/misago/threads/utils.py
@@ -64,7 +64,7 @@ def get_thread_id_from_url(request, url):
     if not resolution.namespaces:
         return None
 
-    url_name = '{}:{}'.format(':'.join(resolution.namespaces), resolution.url_name)
+    url_name = '%s:%s' % (':'.join(resolution.namespaces), resolution.url_name)
     kwargname = SUPPORTED_THREAD_ROUTES.get(url_name)
 
     if not kwargname:

--- a/misago/users/datadownloads/dataarchive.py
+++ b/misago/users/datadownloads/dataarchive.py
@@ -75,7 +75,7 @@ class DataArchive(object):
     def add_text(self, name, value, date=None, directory=None):
         clean_filename = slugify(str(name))
         file_dir_path = self.make_final_path(date=date, directory=directory)
-        file_path = os.path.join(file_dir_path, '{}.txt'.format(clean_filename))
+        file_path = os.path.join(file_dir_path, '%s.txt' % clean_filename)
         with open(file_path, 'w') as fp:
             fp.write(str(value))
             return file_path
@@ -83,7 +83,7 @@ class DataArchive(object):
     def add_dict(self, name, value, date=None, directory=None):
         text_lines = []
         for key, value in value.items():
-            text_lines.append("{}: {}".format(key, value))
+            text_lines.append("%s: %s" % (key, value))
         text = '\n'.join(text_lines)
         return self.add_text(name, text, date=date, directory=directory)
 
@@ -95,7 +95,7 @@ class DataArchive(object):
 
         filename = os.path.basename(model_file.name)
         if prefix:
-            prefixed_filename = "{}-{}".format(prefix, filename)
+            prefixed_filename = "%s-%s" % (prefix, filename)
             clean_filename = trim_long_filename(prefixed_filename)
             target_path = os.path.join(target_dir_path, clean_filename)
         else:
@@ -151,4 +151,4 @@ def trim_long_filename(filename):
 
     name, extension = os.path.splitext(filename)
     name_len = FILENAME_MAX_LEN - len(extension)
-    return '{}{}'.format(name[:name_len], extension)
+    return '%s%s' % (name[:name_len], extension)

--- a/misago/users/management/commands/createsuperuser.py
+++ b/misago/users/management/commands/createsuperuser.py
@@ -171,8 +171,8 @@ class Command(BaseCommand):
             )
 
             if verbosity >= 1:
-                message = "Superuser #{pk} has been created successfully."
-                self.stdout.write(message.format(pk=user.pk))
+                message = "Superuser #%s has been created successfully."
+                self.stdout.write(message % user.pk)
         except ValidationError as e:
             self.stderr.write(e.messages[0])
         except IntegrityError as e:

--- a/misago/users/management/commands/deleteinactiveusers.py
+++ b/misago/users/management/commands/deleteinactiveusers.py
@@ -36,4 +36,4 @@ class Command(BaseCommand):
             user.delete()
             users_deleted += 1
 
-        self.stdout.write("Deleted users: {}".format(users_deleted))
+        self.stdout.write("Deleted users: %s" % users_deleted)

--- a/misago/users/management/commands/deletemarkedusers.py
+++ b/misago/users/management/commands/deletemarkedusers.py
@@ -26,4 +26,4 @@ class Command(BaseCommand):
                 user.delete()
                 users_deleted += 1
 
-        self.stdout.write("Deleted users: {}".format(users_deleted))
+        self.stdout.write("Deleted users: %s" % users_deleted)

--- a/misago/users/management/commands/deleteprofilefield.py
+++ b/misago/users/management/commands/deleteprofilefield.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
                 fields_deleted += 1
 
         self.stdout.write(
-            '"{}" profile field has been deleted from {} users.'.format(
+            '"%s" profile field has been deleted from %s users.' % (
                 fieldname, fields_deleted
             )
         )

--- a/misago/users/management/commands/expireuserdatadownloads.py
+++ b/misago/users/management/commands/expireuserdatadownloads.py
@@ -21,4 +21,4 @@ class Command(BaseCommand):
             expire_user_data_download(data_download)
             downloads_expired += 1
 
-        self.stdout.write("Data downloads expired: {}".format(downloads_expired))
+        self.stdout.write("Data downloads expired: %s" % downloads_expired)

--- a/misago/users/management/commands/invalidatebans.py
+++ b/misago/users/management/commands/invalidatebans.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         queryset = queryset.filter(expires_on__lt=timezone.now())
 
         expired_count = queryset.update(is_checked=False)
-        self.stdout.write("Bans invalidated: {}".format(expired_count))
+        self.stdout.write("Bans invalidated: %s" % expired_count)
 
     def handle_bans_caches(self):
         queryset = BanCache.objects.filter(expires_on__lt=timezone.now())
@@ -34,4 +34,4 @@ class Command(BaseCommand):
         expired_count += queryset.count()
         queryset.delete()
 
-        self.stdout.write("Ban caches emptied: {}".format(expired_count))
+        self.stdout.write("Ban caches emptied: %s" % expired_count)

--- a/misago/users/management/commands/listusedprofilefields.py
+++ b/misago/users/management/commands/listusedprofilefields.py
@@ -22,6 +22,6 @@ class Command(BaseCommand):
             max_len = max([len(k) for k in keys.keys()])
             for key in sorted(keys.keys()):
                 space = ' ' * (max_len + 1 - len(key))
-                self.stdout.write("{}:{}{}".format(key, space, keys[key]))
+                self.stdout.write("%s:%s%s" % (key, space, keys[key]))
         else:
             self.stdout.write("No profile fields are currently in use.")

--- a/misago/users/management/commands/populateonlinetracker.py
+++ b/misago/users/management/commands/populateonlinetracker.py
@@ -18,4 +18,4 @@ class Command(BaseCommand):
             Online.objects.create(user=user, last_click=user.last_login)
             entries_created += 1
 
-        self.stdout.write("Tracker entries created: {}".format(entries_created))
+        self.stdout.write("Tracker entries created: %s" % entries_created)

--- a/misago/users/management/commands/prepareuserdatadownloads.py
+++ b/misago/users/management/commands/prepareuserdatadownloads.py
@@ -39,4 +39,4 @@ class Command(BaseCommand):
 
                 downloads_prepared += 1
 
-        self.stdout.write("Data downloads prepared: {}".format(downloads_prepared))
+        self.stdout.write("Data downloads prepared: %s" % downloads_prepared)

--- a/misago/users/management/commands/removeoldips.py
+++ b/misago/users/management/commands/removeoldips.py
@@ -15,4 +15,4 @@ class Command(BaseCommand):
         remove_old_ips.send(sender=self)
 
         self.stdout.write(
-            "IP addresses older than {} days have been removed.".format(settings.MISAGO_IP_STORE_TIME))
+            "IP addresses older than %s days have been removed." % settings.MISAGO_IP_STORE_TIME)

--- a/misago/users/management/commands/synchronizeusers.py
+++ b/misago/users/management/commands/synchronizeusers.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
     def sync_users(self, users_to_sync):
         categories = Category.objects.root_category().get_descendants()
 
-        self.stdout.write("Synchronizing {} users...\n".format(users_to_sync))
+        self.stdout.write("Synchronizing %s users...\n" % users_to_sync)
 
         synchronized_count = 0
         show_progress(self, synchronized_count, users_to_sync)
@@ -52,4 +52,4 @@ class Command(BaseCommand):
             synchronized_count += 1
             show_progress(self, synchronized_count, users_to_sync, start_time)
 
-        self.stdout.write("\n\nSynchronized {} users".format(synchronized_count))
+        self.stdout.write("\n\nSynchronized %s users" % synchronized_count)

--- a/misago/users/models/datadownload.py
+++ b/misago/users/models/datadownload.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 def get_data_upload_to(instance, filename):
     user_id_hexdigest = md5(str(instance.user_id).encode()).hexdigest()
-    return 'data-downloads/{}/{}/{}.zip'.format(
+    return 'data-downloads/%s/%s/%s.zip' % (
         user_id_hexdigest, get_random_string(64), instance.user.slug)
 
 

--- a/misago/users/profilefields/__init__.py
+++ b/misago/users/profilefields/__init__.py
@@ -34,22 +34,20 @@ class ProfileFields(object):
 
                 if field_path in self.fields_dict:
                     raise ValueError(
-                        "{} profile field has been specified twice".format(field._field_path)
+                        "%s profile field has been specified twice" % field._field_path
                     )
 
                 if not getattr(field, 'fieldname', None):
                     raise ValueError(
-                        "{} profile field has to specify fieldname attribute".format(
-                            field._field_path,
-                        )
+                        "%s profile field has to specify fieldname attribute" % field._field_path
                     )
 
                 if field.fieldname in fieldnames:
                     raise ValueError(
                         (
-                            '{} profile field defines fieldname "{}" '
-                            'that is already in use by the {}'
-                        ).format(
+                            '%s profile field defines fieldname "%s" '
+                            'that is already in use by the %s'
+                        ) % (
                             field._field_path,
                             field.fieldname,
                             fieldnames[field.fieldname],
@@ -146,9 +144,9 @@ class ProfileFields(object):
 
     def log_profile_fields_update(self, request, user):
         if request.user == user:
-            log_message = "{} edited own profile fields".format(user.username)
+            log_message = "%s edited own profile fields" % user.username
         else:
-            log_message = "{} edited {}'s (#{}) profile fields".format(request.user, user.username, user.pk)
+            log_message = "%s edited %s's (#%s) profile fields" % (request.user, user.username, user.pk)
 
         logger.info(
             log_message,

--- a/misago/users/profilefields/basefields.py
+++ b/misago/users/profilefields/basefields.py
@@ -81,7 +81,7 @@ class ProfileField(object):
             return None
 
         return Q(**{
-            'profile_fields__{}__contains'.format(self.fieldname): criteria
+            'profile_fields__%s__contains' % self.fieldname: criteria
         })
 
 
@@ -130,13 +130,13 @@ class ChoiceProfileField(ProfileField):
     def search_users(self, criteria):
         """custom search implementation for choice fields"""
         q_obj = Q(**{
-            'profile_fields__{}__contains'.format(self.fieldname): criteria
+            'profile_fields__%s__contains' % self.fieldname: criteria
         })
 
         for key, choice in self.get_choices():
             if key and criteria.lower() in str(choice).lower():
                 q_obj = q_obj | Q(**{
-                    'profile_fields__{}'.format(self.fieldname): key
+                    'profile_fields__%s' % self.fieldname: key
                 })
 
         return q_obj

--- a/misago/users/profilefields/default.py
+++ b/misago/users/profilefields/default.py
@@ -67,8 +67,8 @@ class TwitterHandleField(basefields.TextProfileField):
 
     def get_value_display_data(self, request, user, value):
         return {
-            'text': '@{}'.format(value),
-            'url': 'https://twitter.com/{}'.format(value),
+            'text': '@%s' % value,
+            'url': 'https://twitter.com/%s' % value,
         }
 
     def clean(self, request, user, data):

--- a/misago/users/tests/test_bio_profilefield.py
+++ b/misago/users/tests/test_bio_profilefield.py
@@ -84,13 +84,13 @@ class BioProfileFieldTests(AdminTestCase):
         """admin users search searches this field"""
         test_link = reverse('misago:admin:users:accounts:index')
 
-        response = self.client.get('{}?redirected=1&profilefields=Ipsum'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=Ipsum' % test_link)
         self.assertContains(response, "No users matching search criteria have been found.")
 
         self.user.profile_fields['bio'] = 'Lorem Ipsum Dolor Met'
         self.user.save()
 
-        response = self.client.get('{}?redirected=1&profilefields=Ipsum'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=Ipsum' % test_link)
         self.assertNotContains(response, "No users matching search criteria have been found.")
 
     def test_field_display(self):

--- a/misago/users/tests/test_datadownloads_dataarchive.py
+++ b/misago/users/tests/test_datadownloads_dataarchive.py
@@ -147,7 +147,7 @@ class DataArchiveTests(AuthenticatedUserTestCase):
             self.assertTrue(str(file_path).startswith(data_dir_path))
             
             filename = os.path.basename(self.user.avatar_tmp.name)
-            target_filename = 'prefix-{}'.format(filename)
+            target_filename = 'prefix-%s' % filename
             self.assertTrue(str(file_path).endswith(target_filename))
 
     def test_make_final_path_no_kwargs(self):
@@ -234,7 +234,7 @@ class TrimLongFilenameTests(TestCase):
         """trim_too_long_filename trims filename if its longer than allowed"""
         filename = 'filename'
         extension = '.jpg'
-        long_filename = '{}{}'.format(filename * 10, extension)
+        long_filename = '%s%s' % (filename * 10, extension)
 
         trimmed_filename = trim_long_filename(long_filename)
         

--- a/misago/users/tests/test_decorators.py
+++ b/misago/users/tests/test_decorators.py
@@ -34,7 +34,7 @@ class DenyGuestsTests(UserTestCase):
 
     def test_ref_login(self):
         """deny_guests decorator redirected guest request to homepage if ref=login"""
-        response = self.client.post('{}?ref=login'.format(reverse('misago:options')))
+        response = self.client.post('%s?ref=login' % reverse('misago:options'))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['location'], reverse('misago:index'))
 

--- a/misago/users/tests/test_gender_profilefield.py
+++ b/misago/users/tests/test_gender_profilefield.py
@@ -108,21 +108,21 @@ class GenderProfileFieldTests(AdminTestCase):
         """admin users search searches this field"""
         test_link = reverse('misago:admin:users:accounts:index')
 
-        response = self.client.get('{}?redirected=1&profilefields=female'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=female' % test_link)
         self.assertContains(response, "No users matching search criteria have been found.")
 
         # search by value
         self.user.profile_fields['gender'] = 'female'
         self.user.save()
 
-        response = self.client.get('{}?redirected=1&profilefields=female'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=female' % test_link)
         self.assertNotContains(response, "No users matching search criteria have been found.")
 
         # search by choice name
         self.user.profile_fields['gender'] = 'secret'
         self.user.save()
 
-        response = self.client.get('{}?redirected=1&profilefields=telling'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=telling' % test_link)
         self.assertNotContains(response, "No users matching search criteria have been found.")
 
     def test_field_display(self):

--- a/misago/users/tests/test_joinip_profilefield.py
+++ b/misago/users/tests/test_joinip_profilefield.py
@@ -56,7 +56,7 @@ class JoinIpProfileFieldTests(AdminTestCase):
         """admin users search searches this field"""
         test_link = reverse('misago:admin:users:accounts:index')
 
-        response = self.client.get('{}?redirected=1&profilefields=127.0.0.1'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=127.0.0.1' % test_link)
         self.assertContains(response, "No users matching search criteria have been found.")
 
     def test_field_display(self):

--- a/misago/users/tests/test_twitter_profilefield.py
+++ b/misago/users/tests/test_twitter_profilefield.py
@@ -108,13 +108,13 @@ class TwitterProfileFieldTests(AdminTestCase):
         """admin users search searches this field"""
         test_link = reverse('misago:admin:users:accounts:index')
 
-        response = self.client.get('{}?redirected=1&profilefields=ipsum'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=ipsum' % test_link)
         self.assertContains(response, "No users matching search criteria have been found.")
 
         self.user.profile_fields['twitter'] = 'lorem_ipsum'
         self.user.save()
 
-        response = self.client.get('{}?redirected=1&profilefields=ipsum'.format(test_link))
+        response = self.client.get('%s?redirected=1&profilefields=ipsum' % test_link)
         self.assertNotContains(response, "No users matching search criteria have been found.")
 
     def test_field_display(self):

--- a/misago/users/tests/test_user_middleware.py
+++ b/misago/users/tests/test_user_middleware.py
@@ -41,7 +41,7 @@ class UserMiddlewareTest(AuthenticatedUserTestCase):
         """middleware ignores registration only bans"""
         Ban.objects.create(
             check_type=Ban.USERNAME,
-            banned_value='{}*'.format(self.user.username[:3]),
+            banned_value='%s*' % self.user.username[:3],
             registration_only=True,
         )
         

--- a/misago/users/views/auth.py
+++ b/misago/users/views/auth.py
@@ -25,10 +25,10 @@ def login(request):
             if is_redirect_safe:
                 redirect_to_path = urlparse(redirect_to).path
                 if '?' not in redirect_to_path:
-                    redirect_to_path = '{}?'.format(redirect_to_path)
+                    redirect_to_path = '%s?' % redirect_to_path
                 else:
-                    redirect_to_path = '{}&'.format(redirect_to_path)
-                redirect_to_path = '{}ref=login'.format(redirect_to_path)
+                    redirect_to_path = '%s&' % redirect_to_path
+                redirect_to_path = '%sref=login' % redirect_to_path
                 try:
                     return redirect(redirect_to_path)
                 except NoReverseMatch:


### PR DESCRIPTION
This PR reverts most of code back to old text format syntax using `%`, which I like because its more terse than `.format()`.