### PR TITLE
Remove u prefix from gettext functions

### DIFF
--- a/misago/acl/admin.py
+++ b/misago/acl/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .views import DeleteRole, EditRole, NewRole, RolesList, RoleUsers
 

--- a/misago/acl/forms.py
+++ b/misago/acl/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Role
 from .providers import providers

--- a/misago/acl/models.py
+++ b/misago/acl/models.py
@@ -1,6 +1,6 @@
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from . import version as acl_version
 

--- a/misago/acl/panels.py
+++ b/misago/acl/panels.py
@@ -1,6 +1,6 @@
 from debug_toolbar.panels import Panel
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MisagoACLPanel(Panel):

--- a/misago/acl/views.py
+++ b/misago/acl/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 

--- a/misago/admin/admin.py
+++ b/misago/admin/admin.py
@@ -1,5 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MisagoAdminExtension(MiddlewareMixin):

--- a/misago/admin/auth.py
+++ b/misago/admin/auth.py
@@ -3,7 +3,7 @@ from time import time
 
 from django.contrib import auth as dj_auth
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 

--- a/misago/admin/forms.py
+++ b/misago/admin/forms.py
@@ -1,5 +1,5 @@
 from django.forms import DateTimeField, RadioSelect, TypedChoiceField, ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.core.utils import parse_iso8601_string
 

--- a/misago/admin/views/auth.py
+++ b/misago/admin/views/auth.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.shortcuts import redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters

--- a/misago/admin/views/generic/list.py
+++ b/misago/admin/views/generic/list.py
@@ -5,7 +5,7 @@ from django.core.paginator import EmptyPage, Paginator
 from django.db import transaction
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.core.exceptions import ExplicitFirstPage
 

--- a/misago/admin/views/index.py
+++ b/misago/admin/views/index.py
@@ -3,7 +3,7 @@ from requests.exceptions import RequestException
 
 from django.contrib.auth import get_user_model
 from django.http import Http404, JsonResponse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago import __version__
 from misago.conf import settings

--- a/misago/categories/admin.py
+++ b/misago/categories/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .views.categoriesadmin import (
     CategoriesList, DeleteCategory, EditCategory, MoveDownCategory, MoveUpCategory, NewCategory)

--- a/misago/categories/forms.py
+++ b/misago/categories/forms.py
@@ -3,7 +3,7 @@ from mptt.forms import TreeNodeChoiceField, TreeNodeMultipleChoiceField
 from django import forms
 from django.db import models
 from django.utils.html import conditional_escape, mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.forms import YesNoSwitch
 from misago.core.validators import validate_sluggable

--- a/misago/categories/permissions.py
+++ b/misago/categories/permissions.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean

--- a/misago/categories/views/categoriesadmin.py
+++ b/misago/categories/views/categoriesadmin.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import version as acl_version
 from misago.admin.views import generic

--- a/misago/categories/views/permsadmin.py
+++ b/misago/categories/views/permsadmin.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import version as acl_version
 from misago.acl.forms import get_permissions_forms

--- a/misago/conf/admin.py
+++ b/misago/conf/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import views
 

--- a/misago/conf/forms.py
+++ b/misago/conf/forms.py
@@ -1,6 +1,6 @@
 from django import forms
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from misago.admin.forms import YesNoSwitch
 
@@ -17,7 +17,7 @@ class ValidateChoicesNum(object):
         data_len = len(data)
 
         if self.min_choices and self.min_choices > data_len:
-            message = ungettext(
+            message = ngettext(
                 'You have to select at least %(choices)d option.',
                 'You have to select at least %(choices)d options.',
                 self.min_choices,
@@ -25,7 +25,7 @@ class ValidateChoicesNum(object):
             raise forms.ValidationError(message % {'choices': self.min_choices})
 
         if self.max_choices and self.max_choices < data_len:
-            message = ungettext(
+            message = ngettext(
                 'You cannot select more than %(choices)d option.',
                 'You cannot select more than %(choices)d options.',
                 self.max_choices,

--- a/misago/conf/models.py
+++ b/misago/conf/models.py
@@ -6,7 +6,7 @@ from . import utils
 
 class SettingsGroupsManager(models.Manager):
     def ordered_alphabetically(self):
-        from django.utils.translation import ugettext as _
+        from django.utils.translation import gettext as _
 
         groups_dict = {}
 

--- a/misago/conf/views.py
+++ b/misago/conf/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.admin.views import render as mi_render
 

--- a/misago/core/admin.py
+++ b/misago/core/admin.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MisagoAdminExtension(object):

--- a/misago/core/errorpages.py
+++ b/misago/core/errorpages.py
@@ -1,6 +1,6 @@
 from django.http import JsonResponse
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from social_core import exceptions as social_exceptions
 
 from misago.admin.views.errorpages import admin_csrf_failure, admin_error_page

--- a/misago/core/rest_permissions.py
+++ b/misago/core/rest_permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class IsAuthenticatedOrReadOnly(BasePermission):

--- a/misago/core/templatetags/misago_pagetitle.py
+++ b/misago/core/templatetags/misago_pagetitle.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 register = template.Library()

--- a/misago/core/validators.py
+++ b/misago/core/validators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .utils import slugify
 

--- a/misago/legal/admin.py
+++ b/misago/legal/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .views.admin import (
     AgreementsList, DeleteAgreement, EditAgreement, NewAgreement, SetAgreementAsActive

--- a/misago/legal/api.py
+++ b/misago/legal/api.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import logout
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response

--- a/misago/legal/forms.py
+++ b/misago/legal/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.db.models import Q
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Agreement
 from .utils import set_agreement_as_active

--- a/misago/legal/models.py
+++ b/misago/legal/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.conf import settings
 from misago.core.cache import cache

--- a/misago/legal/views/admin.py
+++ b/misago/legal/views/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 

--- a/misago/markup/finalise.py
+++ b/misago/markup/finalise.py
@@ -1,6 +1,6 @@
 import re
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 HEADER_RE = re.compile(

--- a/misago/search/api.py
+++ b/misago/search/api.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.shortcuts import get_int_or_404
 

--- a/misago/search/permissions.py
+++ b/misago/search/permissions.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.models import Role

--- a/misago/search/views.py
+++ b/misago/search/views.py
@@ -2,7 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .searchproviders import searchproviders
 

--- a/misago/threads/admin.py
+++ b/misago/threads/admin.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .views.admin.attachments import AttachmentsList, DeleteAttachment
 from .views.admin.attachmenttypes import (

--- a/misago/threads/api/attachments.py
+++ b/misago/threads/api/attachments.py
@@ -3,7 +3,7 @@ from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.template.defaultfilters import filesizeformat
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.threads.models import Attachment, AttachmentType

--- a/misago/threads/api/postendpoints/delete.py
+++ b/misago/threads/api/postendpoints/delete.py
@@ -1,8 +1,8 @@
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from misago.conf import settings
 from misago.core.utils import clean_ids_list

--- a/misago/threads/api/postendpoints/edits.py
+++ b/misago/threads/api/postendpoints/edits.py
@@ -4,7 +4,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import F
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.core.shortcuts import get_int_or_404

--- a/misago/threads/api/postendpoints/merge.py
+++ b/misago/threads/api/postendpoints/merge.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.threads.serializers import MergePostsSerializer, PostSerializer

--- a/misago/threads/api/postendpoints/move.py
+++ b/misago/threads/api/postendpoints/move.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.threads.serializers import MovePostsSerializer
 

--- a/misago/threads/api/postendpoints/patch_event.py
+++ b/misago/threads/api/postendpoints/patch_event.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.core.apipatch import ApiPatch

--- a/misago/threads/api/postendpoints/patch_post.py
+++ b/misago/threads/api/postendpoints/patch_post.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.conf import settings

--- a/misago/threads/api/postendpoints/split.py
+++ b/misago/threads/api/postendpoints/split.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.threads.models import Thread
 from misago.threads.moderation import threads as moderation

--- a/misago/threads/api/postingendpoint/attachments.py
+++ b/misago/threads/api/postingendpoint/attachments.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from misago.acl import add_acl
 from misago.conf import settings
@@ -123,7 +123,7 @@ class AttachmentsSerializer(serializers.Serializer):
 def validate_attachments_count(data):
     total_attachments = len(data)
     if total_attachments > settings.MISAGO_POST_ATTACHMENTS_LIMIT:
-        message = ungettext(
+        message = ngettext(
             "You can't attach more than %(limit_value)s file to single post (added %(show_value)s).",
             "You can't attach more than %(limit_value)s flies to single post (added %(show_value)s).",
             settings.MISAGO_POST_ATTACHMENTS_LIMIT,

--- a/misago/threads/api/postingendpoint/category.py
+++ b/misago/threads/api/postingendpoint/category.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from misago.acl import add_acl
 from misago.categories import THREADS_ROOT_NAME
@@ -42,8 +42,8 @@ class CategoryMiddleware(PostingMiddleware):
 class CategorySerializer(serializers.Serializer):
     category = serializers.IntegerField(
         error_messages={
-            'required': ugettext_lazy("You have to select category to post thread in."),
-            'invalid': ugettext_lazy("Selected category is invalid."),
+            'required': gettext_lazy("You have to select category to post thread in."),
+            'invalid': gettext_lazy("Selected category is invalid."),
         }
     )
 

--- a/misago/threads/api/postingendpoint/emailnotification.py
+++ b/misago/threads/api/postingendpoint/emailnotification.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.mail import build_mail, send_messages
 from misago.threads.permissions import can_see_post, can_see_thread

--- a/misago/threads/api/postingendpoint/floodprotection.py
+++ b/misago/threads/api/postingendpoint/floodprotection.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 

--- a/misago/threads/api/postingendpoint/participants.py
+++ b/misago/threads/api/postingendpoint/participants.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _, ungettext
+from django.utils.translation import gettext as _, ngettext
 
 from misago.categories import PRIVATE_THREADS_ROOT_NAME
 from misago.threads.participants import add_participants, set_owner
@@ -53,7 +53,7 @@ class ParticipantsSerializer(serializers.Serializer):
 
         max_participants = self.context['user'].acl_cache['max_private_thread_participants']
         if max_participants and len(clean_usernames) > max_participants:
-            message = ungettext(
+            message = ngettext(
                 "You can't add more than %(users)s user to private thread (you've added %(added)s).",
                 "You can't add more than %(users)s users to private thread (you've added %(added)s).",
                 max_participants,

--- a/misago/threads/api/postingendpoint/reply.py
+++ b/misago/threads/api/postingendpoint/reply.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from misago.markup import common_flavour
 from misago.threads.checksums import update_post_checksum
@@ -80,7 +80,7 @@ class ReplySerializer(serializers.Serializer):
     post = serializers.CharField(
         validators=[validate_post_length],
         error_messages={
-            'required': ugettext_lazy("You have to enter a message."),
+            'required': gettext_lazy("You have to enter a message."),
         }
     )
 
@@ -102,6 +102,6 @@ class ThreadSerializer(ReplySerializer):
     title = serializers.CharField(
         validators=[validate_title],
         error_messages={
-            'required': ugettext_lazy("You have to enter thread title."),
+            'required': gettext_lazy("You have to enter thread title."),
         }
     )

--- a/misago/threads/api/threadendpoints/editor.py
+++ b/misago/threads/api/threadendpoints/editor.py
@@ -1,7 +1,7 @@
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.categories import THREADS_ROOT_NAME

--- a/misago/threads/api/threadendpoints/merge.py
+++ b/misago/threads/api/threadendpoints/merge.py
@@ -2,7 +2,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.threads.events import record_event

--- a/misago/threads/api/threadendpoints/patch.py
+++ b/misago/threads/api/threadendpoints/patch.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.categories.models import Category

--- a/misago/threads/api/threadpoll.py
+++ b/misago/threads/api/threadpoll.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import Http404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.core.shortcuts import get_int_or_404

--- a/misago/threads/api/threadposts.py
+++ b/misago/threads/api/threadposts.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.core.shortcuts import get_int_or_404

--- a/misago/threads/api/threads.py
+++ b/misago/threads/api/threads.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.categories import PRIVATE_THREADS_ROOT_NAME, THREADS_ROOT_NAME
 from misago.core.shortcuts import get_int_or_404

--- a/misago/threads/forms.py
+++ b/misago/threads/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .models import AttachmentType
 

--- a/misago/threads/mergeconflict.py
+++ b/misago/threads/mergeconflict.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.threads.models import Poll
 

--- a/misago/threads/models/attachmenttype.py
+++ b/misago/threads/models/attachmenttype.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AttachmentType(models.Model):

--- a/misago/threads/models/thread.py
+++ b/misago/threads/models/thread.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.conf import settings
 from misago.core.pgutils import PgPartialIndex

--- a/misago/threads/moderation/posts.py
+++ b/misago/threads/moderation/posts.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from .exceptions import ModerationError
 

--- a/misago/threads/participants.py
+++ b/misago/threads/participants.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.mail import build_mail, send_messages
 

--- a/misago/threads/permissions/attachments.py
+++ b/misago/threads/permissions/attachments.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.models import Role

--- a/misago/threads/permissions/bestanswers.py
+++ b/misago/threads/permissions/bestanswers.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _, ungettext
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean
@@ -200,7 +200,7 @@ def allow_change_best_answer(user, target):
             )
         if not has_time_to_change_answer(user, target):
             raise PermissionDenied(
-                ungettext(
+                ngettext(
                     (
                         "You don't have permission to change best answer that was marked for more "
                         "than %(minutes)s minute."
@@ -256,7 +256,7 @@ def allow_unmark_best_answer(user, target):
             )
         if not has_time_to_change_answer(user, target):
             raise PermissionDenied(
-                ungettext(
+                ngettext(
                     (
                         "You don't have permission to unmark best answer that was marked for more "
                         "than %(minutes)s minute."

--- a/misago/threads/permissions/polls.py
+++ b/misago/threads/permissions/polls.py
@@ -1,8 +1,8 @@
 from django import forms
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean
@@ -160,7 +160,7 @@ def allow_edit_poll(user, target):
         if user.pk != target.poster_id:
             raise PermissionDenied(_("You can't edit other users polls in this category."))
         if not has_time_to_edit_poll(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't edit polls that are older than %(minutes)s minute.",
                 "You can't edit polls that are older than %(minutes)s minutes.",
                 user.acl_cache['poll_edit_time']
@@ -197,7 +197,7 @@ def allow_delete_poll(user, target):
         if user.pk != target.poster_id:
             raise PermissionDenied(_("You can't delete other users polls in this category."))
         if not has_time_to_edit_poll(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't delete polls that are older than %(minutes)s minute.",
                 "You can't delete polls that are older than %(minutes)s minutes.",
                 user.acl_cache['poll_edit_time']

--- a/misago/threads/permissions/privatethreads.py
+++ b/misago/threads/permissions/privatethreads.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean

--- a/misago/threads/permissions/threads.py
+++ b/misago/threads/permissions/threads.py
@@ -3,7 +3,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.http import Http404
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _, ungettext
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from misago.acl import add_acl, algebra
 from misago.acl.decorators import return_boolean
@@ -622,7 +622,7 @@ def allow_edit_thread(user, target):
             raise PermissionDenied(_("You can't edit other users threads in this category."))
 
         if not has_time_to_edit_thread(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't edit threads that are older than %(minutes)s minute.",
                 "You can't edit threads that are older than %(minutes)s minutes.",
                 category_acl['thread_edit_time']
@@ -701,7 +701,7 @@ def allow_hide_thread(user, target):
             raise PermissionDenied(_("You can't hide other users theads in this category."))
 
         if not has_time_to_edit_thread(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't hide threads that are older than %(minutes)s minute.",
                 "You can't hide threads that are older than %(minutes)s minutes.",
                 category_acl['thread_edit_time'],
@@ -737,7 +737,7 @@ def allow_delete_thread(user, target):
             raise PermissionDenied(_("You can't delete other users theads in this category."))
 
         if not has_time_to_edit_thread(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't delete threads that are older than %(minutes)s minute.",
                 "You can't delete threads that are older than %(minutes)s minutes.",
                 category_acl['thread_edit_time'],
@@ -874,7 +874,7 @@ def allow_edit_post(user, target):
             raise PermissionDenied(_("This post is protected. You can't edit it."))
 
         if not has_time_to_edit_post(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't edit posts that are older than %(minutes)s minute.",
                 "You can't edit posts that are older than %(minutes)s minutes.",
                 category_acl['post_edit_time'],
@@ -913,7 +913,7 @@ def allow_unhide_post(user, target):
             raise PermissionDenied(_("This post is protected. You can't reveal it."))
 
         if not has_time_to_edit_post(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't reveal posts that are older than %(minutes)s minute.",
                 "You can't reveal posts that are older than %(minutes)s minutes.",
                 category_acl['post_edit_time'],
@@ -955,7 +955,7 @@ def allow_hide_post(user, target):
             raise PermissionDenied(_("This post is protected. You can't hide it."))
 
         if not has_time_to_edit_post(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't hide posts that are older than %(minutes)s minute.",
                 "You can't hide posts that are older than %(minutes)s minutes.",
                 category_acl['post_edit_time'],
@@ -997,7 +997,7 @@ def allow_delete_post(user, target):
             raise PermissionDenied(_("This post is protected. You can't delete it."))
 
         if not has_time_to_edit_post(user, target):
-            message = ungettext(
+            message = ngettext(
                 "You can't delete posts that are older than %(minutes)s minute.",
                 "You can't delete posts that are older than %(minutes)s minutes.",
                 category_acl['post_edit_time'],

--- a/misago/threads/search.py
+++ b/misago/threads/search.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.conf import settings
 from misago.core.shortcuts import paginate, pagination_dict

--- a/misago/threads/serializers/moderation.py
+++ b/misago/threads/serializers/moderation.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.http import Http404
-from django.utils.translation import ugettext as _, ugettext_lazy, ungettext
+from django.utils.translation import gettext as _, gettext_lazy, ngettext
 
 from misago.acl import add_acl
 from misago.categories import THREADS_ROOT_NAME
@@ -37,13 +37,13 @@ __all__ = [
 
 
 class DeletePostsSerializer(serializers.Serializer):
-    error_empty_or_required = ugettext_lazy("You have to specify at least one post to delete.")
+    error_empty_or_required = gettext_lazy("You have to specify at least one post to delete.")
 
     posts = serializers.ListField(
         allow_empty=False,
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more post ids received were invalid."),
+                'invalid': gettext_lazy("One or more post ids received were invalid."),
             },
         ),
         error_messages={
@@ -55,7 +55,7 @@ class DeletePostsSerializer(serializers.Serializer):
 
     def validate_posts(self, data):
         if len(data) > POSTS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s post can be deleted at single time.",
                 "No more than %(limit)s posts can be deleted at single time.",
                 POSTS_LIMIT,
@@ -88,12 +88,12 @@ class DeletePostsSerializer(serializers.Serializer):
 
 
 class MergePostsSerializer(serializers.Serializer):
-    error_empty_or_required = ugettext_lazy("You have to select at least two posts to merge.")
+    error_empty_or_required = gettext_lazy("You have to select at least two posts to merge.")
 
     posts = serializers.ListField(
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more post ids received were invalid."),
+                'invalid': gettext_lazy("One or more post ids received were invalid."),
             },
         ),
         error_messages={
@@ -108,7 +108,7 @@ class MergePostsSerializer(serializers.Serializer):
         if len(data) < 2:
             raise serializers.ValidationError(self.error_empty_or_required)
         if len(data) > POSTS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s post can be merged at single time.",
                 "No more than %(limit)s posts can be merged at single time.",
                 POSTS_LIMIT,
@@ -163,18 +163,18 @@ class MergePostsSerializer(serializers.Serializer):
 
 
 class MovePostsSerializer(serializers.Serializer):
-    error_empty_or_required = ugettext_lazy("You have to specify at least one post to move.")
+    error_empty_or_required = gettext_lazy("You have to specify at least one post to move.")
 
     new_thread = serializers.CharField(
         error_messages={
-            'required': ugettext_lazy("Enter link to new thread."),
+            'required': gettext_lazy("Enter link to new thread."),
         },
     )
     posts = serializers.ListField(
         allow_empty=False,
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more post ids received were invalid."),
+                'invalid': gettext_lazy("One or more post ids received were invalid."),
             },
         ),
         error_messages={
@@ -213,7 +213,7 @@ class MovePostsSerializer(serializers.Serializer):
     def validate_posts(self, data):
         data = list(set(data))
         if len(data) > POSTS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s post can be moved at single time.",
                 "No more than %(limit)s posts can be moved at single time.",
                 POSTS_LIMIT,
@@ -305,13 +305,13 @@ class NewThreadSerializer(serializers.Serializer):
 
 
 class SplitPostsSerializer(NewThreadSerializer):
-    error_empty_or_required = ugettext_lazy("You have to specify at least one post to split.")
+    error_empty_or_required = gettext_lazy("You have to specify at least one post to split.")
 
     posts = serializers.ListField(
         allow_empty=False,
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more post ids received were invalid."),
+                'invalid': gettext_lazy("One or more post ids received were invalid."),
             },
         ),
         error_messages={
@@ -323,7 +323,7 @@ class SplitPostsSerializer(NewThreadSerializer):
 
     def validate_posts(self, data):
         if len(data) > POSTS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s post can be split at single time.",
                 "No more than %(limit)s posts can be split at single time.",
                 POSTS_LIMIT,
@@ -355,13 +355,13 @@ class SplitPostsSerializer(NewThreadSerializer):
 
 
 class DeleteThreadsSerializer(serializers.Serializer):
-    error_empty_or_required = ugettext_lazy("You have to specify at least one thread to delete.")
+    error_empty_or_required = gettext_lazy("You have to specify at least one thread to delete.")
 
     threads = serializers.ListField(
         allow_empty=False,
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more thread ids received were invalid."),
+                'invalid': gettext_lazy("One or more thread ids received were invalid."),
             },
         ),
         error_messages={
@@ -373,7 +373,7 @@ class DeleteThreadsSerializer(serializers.Serializer):
 
     def validate_threads(self, data):
         if len(data) > THREADS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s thread can be deleted at single time.",
                 "No more than %(limit)s threads can be deleted at single time.",
                 THREADS_LIMIT,
@@ -414,19 +414,19 @@ class DeleteThreadsSerializer(serializers.Serializer):
 class MergeThreadSerializer(serializers.Serializer):
     other_thread = serializers.CharField(
         error_messages={
-            'required': ugettext_lazy("Enter link to new thread."),
+            'required': gettext_lazy("Enter link to new thread."),
         },
     )
     best_answer = serializers.IntegerField(
         required=False,
         error_messages={
-            'invalid': ugettext_lazy("Invalid choice."),
+            'invalid': gettext_lazy("Invalid choice."),
         },
     )
     poll = serializers.IntegerField(
         required=False,
         error_messages={
-            'invalid': ugettext_lazy("Invalid choice."),
+            'invalid': gettext_lazy("Invalid choice."),
         },
     )
 
@@ -472,14 +472,14 @@ class MergeThreadSerializer(serializers.Serializer):
 
 
 class MergeThreadsSerializer(NewThreadSerializer):
-    error_empty_or_required = ugettext_lazy("You have to select at least two threads to merge.")
+    error_empty_or_required = gettext_lazy("You have to select at least two threads to merge.")
 
     threads = serializers.ListField(
         allow_empty=False,
         min_length=2,
         child=serializers.IntegerField(
             error_messages={
-                'invalid': ugettext_lazy("One or more thread ids received were invalid."),
+                'invalid': gettext_lazy("One or more thread ids received were invalid."),
             },
         ),
         error_messages={
@@ -492,19 +492,19 @@ class MergeThreadsSerializer(NewThreadSerializer):
     best_answer = serializers.IntegerField(
         required=False,
         error_messages={
-            'invalid': ugettext_lazy("Invalid choice."),
+            'invalid': gettext_lazy("Invalid choice."),
         },
     )
     poll = serializers.IntegerField(
         required=False,
         error_messages={
-            'invalid': ugettext_lazy("Invalid choice."),
+            'invalid': gettext_lazy("Invalid choice."),
         },
     )
 
     def validate_threads(self, data):
         if len(data) > THREADS_LIMIT:
-            message = ungettext(
+            message = ngettext(
                 "No more than %(limit)s thread can be merged at single time.",
                 "No more than %(limit)s threads can be merged at single time.",
                 POSTS_LIMIT,

--- a/misago/threads/serializers/poll.py
+++ b/misago/threads/serializers/poll.py
@@ -2,8 +2,8 @@ from rest_framework import serializers
 
 from django.urls import reverse
 from django.utils.crypto import get_random_string
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from misago.threads.models import Poll
 
@@ -137,7 +137,7 @@ class EditPollSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(_("You need to add at least two choices to a poll."))
 
         if total_choices > MAX_POLL_OPTIONS:
-            message = ungettext(
+            message = ngettext(
                 "You can't add more than %(limit_value)s option to a single poll (added %(show_value)s).",
                 "You can't add more than %(limit_value)s options to a single poll (added %(show_value)s).",
                 MAX_POLL_OPTIONS,

--- a/misago/threads/serializers/pollvote.py
+++ b/misago/threads/serializers/pollvote.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
 
 from django.urls import reverse
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 
 __all__ = [
@@ -18,7 +18,7 @@ class NewVoteSerializer(serializers.Serializer):
 
     def validate_choices(self, data):
         if len(data) > self.context['allowed_choices']:
-            message = ungettext(
+            message = ngettext(
                 "This poll disallows voting for more than %(choices)s choice.",
                 "This poll disallows voting for more than %(choices)s choices.",
                 self.context['allowed_choices']

--- a/misago/threads/signals.py
+++ b/misago/threads/signals.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import Signal, receiver
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.categories.models import Category
 from misago.categories.signals import delete_category_content, move_category_content

--- a/misago/threads/templatetags/misago_poststags.py
+++ b/misago/threads/templatetags/misago_poststags.py
@@ -1,6 +1,6 @@
 from django import template
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 
 register = template.Library()
@@ -28,7 +28,7 @@ def likes_label(post):
 
     formats = {'users': usernames_string, 'likes': hidden_likes}
 
-    return ungettext(
+    return ngettext(
         "%(users)s and %(likes)s other user like this.",
         "%(users)s and %(likes)s other users like this.",
         hidden_likes,

--- a/misago/threads/threadtypes/privatethread.py
+++ b/misago/threads/threadtypes/privatethread.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.categories import PRIVATE_THREADS_ROOT_NAME
 

--- a/misago/threads/threadtypes/thread.py
+++ b/misago/threads/threadtypes/thread.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.categories import THREADS_ROOT_NAME
 

--- a/misago/threads/validators.py
+++ b/misago/threads/validators.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from misago.categories import THREADS_ROOT_NAME
 from misago.categories.models import Category
@@ -41,7 +41,7 @@ def validate_title(title):
         raise ValidationError(_("You have to enter thread title."))
 
     if title_len < settings.thread_title_length_min:
-        message = ungettext(
+        message = ngettext(
             "Thread title should be at least %(limit_value)s character long (it has %(show_value)s).",
             "Thread title should be at least %(limit_value)s characters long (it has %(show_value)s).",
             settings.thread_title_length_min,
@@ -54,7 +54,7 @@ def validate_title(title):
         )
 
     if title_len > settings.thread_title_length_max:
-        message = ungettext(
+        message = ngettext(
             "Thread title cannot be longer than %(limit_value)s character (it has %(show_value)s).",
             "Thread title cannot be longer than %(limit_value)s characters (it has %(show_value)s).",
             settings.thread_title_length_max,
@@ -80,7 +80,7 @@ def validate_post_length(post):
         raise ValidationError(_("You have to enter a message."))
 
     if post_len < settings.post_length_min:
-        message = ungettext(
+        message = ngettext(
             "Posted message should be at least %(limit_value)s character long (it has %(show_value)s).",
             "Posted message should be at least %(limit_value)s characters long (it has %(show_value)s).",
             settings.post_length_min,
@@ -93,7 +93,7 @@ def validate_post_length(post):
         )
 
     if settings.post_length_max and post_len > settings.post_length_max:
-        message = ungettext(
+        message = ngettext(
             "Posted message cannot be longer than %(limit_value)s character (it has %(show_value)s).",
             "Posted message cannot be longer than %(limit_value)s characters (it has %(show_value)s).",
             settings.post_length_max,

--- a/misago/threads/viewmodels/thread.py
+++ b/misago/threads/viewmodels/thread.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.categories import PRIVATE_THREADS_ROOT_NAME, THREADS_ROOT_NAME

--- a/misago/threads/viewmodels/threads.py
+++ b/misago/threads/viewmodels/threads.py
@@ -4,8 +4,8 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import F, Q
 from django.http import Http404
 from django.utils import timezone
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from misago.acl import add_acl
 from misago.conf import settings
@@ -24,19 +24,19 @@ __all__ = ['ForumThreads', 'PrivateThreads', 'filter_read_threads_queryset']
 
 LISTS_NAMES = {
     'all': None,
-    'my': ugettext_lazy("Your threads"),
-    'new': ugettext_lazy("New threads"),
-    'unread': ugettext_lazy("Unread threads"),
-    'subscribed': ugettext_lazy("Subscribed threads"),
-    'unapproved': ugettext_lazy("Unapproved content"),
+    'my': gettext_lazy("Your threads"),
+    'new': gettext_lazy("New threads"),
+    'unread': gettext_lazy("Unread threads"),
+    'subscribed': gettext_lazy("Subscribed threads"),
+    'unapproved': gettext_lazy("Unapproved content"),
 }
 
 LIST_DENIED_MESSAGES = {
-    'my': ugettext_lazy("You have to sign in to see list of threads that you have started."),
-    'new': ugettext_lazy("You have to sign in to see list of threads you haven't read."),
-    'unread': ugettext_lazy("You have to sign in to see list of threads with new replies."),
-    'subscribed': ugettext_lazy("You have to sign in to see list of threads you are subscribing."),
-    'unapproved': ugettext_lazy("You have to sign in to see list of threads with unapproved posts."),
+    'my': gettext_lazy("You have to sign in to see list of threads that you have started."),
+    'new': gettext_lazy("You have to sign in to see list of threads you haven't read."),
+    'unread': gettext_lazy("You have to sign in to see list of threads with new replies."),
+    'subscribed': gettext_lazy("You have to sign in to see list of threads you are subscribing."),
+    'unapproved': gettext_lazy("You have to sign in to see list of threads with unapproved posts."),
 }
 
 

--- a/misago/threads/views/admin/attachments.py
+++ b/misago/threads/views/admin/attachments.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.db import transaction
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 from misago.threads.forms import SearchAttachmentsForm

--- a/misago/threads/views/admin/attachmenttypes.py
+++ b/misago/threads/views/admin/attachmenttypes.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.db.models import Count
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 from misago.threads.forms import AttachmentTypeForm

--- a/misago/threads/views/goto.py
+++ b/misago/threads/views/goto.py
@@ -3,7 +3,7 @@ from math import ceil
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views import View
 
 from misago.conf import settings

--- a/misago/users/admin.py
+++ b/misago/users/admin.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from django.contrib import admin as djadmin
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .djangoadmin import UserAdminModel
 from .views.admin.bans import BansList, DeleteBan, EditBan, NewBan

--- a/misago/users/api/auth.py
+++ b/misago/users/api/auth.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from django.contrib import auth
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_protect
 
 from misago.conf import settings

--- a/misago/users/api/rest_permissions.py
+++ b/misago/users/api/rest_permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.permissions import BasePermission
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.exceptions import Banned
 from misago.users.bans import get_request_ip_ban

--- a/misago/users/api/userendpoints/avatar.py
+++ b/misago/users/api/userendpoints/avatar.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.decorators import require_dict_data

--- a/misago/users/api/userendpoints/changeemail.py
+++ b/misago/users/api/userendpoints/changeemail.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.mail import mail_user

--- a/misago/users/api/userendpoints/changepassword.py
+++ b/misago/users/api/userendpoints/changepassword.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.response import Response
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.mail import mail_user

--- a/misago/users/api/userendpoints/create.py
+++ b/misago/users/api/userendpoints/create.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from django.contrib.auth import authenticate, get_user_model, login
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_protect
 
 from misago.conf import settings

--- a/misago/users/api/userendpoints/signature.py
+++ b/misago/users/api/userendpoints/signature.py
@@ -2,7 +2,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.utils import format_plaintext_for_html

--- a/misago/users/api/userendpoints/username.py
+++ b/misago/users/api/userendpoints/username.py
@@ -2,7 +2,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from django.db import IntegrityError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.users.namechanges import UsernameChanges

--- a/misago/users/api/usernamechanges.py
+++ b/misago/users/api/usernamechanges.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.shortcuts import get_int_or_404, paginate, pagination_dict
 from misago.users.models import UsernameChange

--- a/misago/users/api/users.py
+++ b/misago/users/api/users.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.db.models import F
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.acl import add_acl
 from misago.categories.models import Category

--- a/misago/users/apps.py
+++ b/misago/users/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.conf import settings
 

--- a/misago/users/avatars/uploaded.py
+++ b/misago/users/avatars/uploaded.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from PIL import Image
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 

--- a/misago/users/captcha.py
+++ b/misago/users/captcha.py
@@ -1,7 +1,7 @@
 import requests
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 

--- a/misago/users/decorators.py
+++ b/misago/users/decorators.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.exceptions import Banned
 

--- a/misago/users/djangoadmin.py
+++ b/misago/users/djangoadmin.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import ModelAdmin
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class UserAdminModel(ModelAdmin):

--- a/misago/users/forms/admin.py
+++ b/misago/users/forms/admin.py
@@ -2,8 +2,8 @@ from django import forms
 from django.db.models import Q
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from misago.acl.models import Role
 from misago.admin.forms import IsoDateTimeField, YesNoSwitch
@@ -217,7 +217,7 @@ class EditUserForm(UserBaseForm):
         length_limit = settings.signature_length_max
         if len(data) > length_limit:
             raise forms.ValidationError(
-                ungettext(
+                ngettext(
                     "Signature can't be longer than %(limit)s character.",
                     "Signature can't be longer than %(limit)s characters.",
                     length_limit,

--- a/misago/users/forms/auth.py
+++ b/misago/users/forms/auth.py
@@ -3,7 +3,7 @@ from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.forms import AuthenticationForm as BaseAuthenticationForm
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.users.bans import get_user_ban
 

--- a/misago/users/forms/register.py
+++ b/misago/users/forms/register.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.users import validators
 from misago.users.bans import get_email_ban, get_ip_ban, get_username_ban

--- a/misago/users/management/commands/prepareuserdatadownloads.py
+++ b/misago/users/management/commands/prepareuserdatadownloads.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 
 from misago.conf import settings
 from misago.core.mail import mail_user
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         for data_download in chunk_queryset(queryset):
             if prepare_user_data_download(data_download, logger):
                 user = data_download.user
-                subject = ugettext("%(user)s, your data download is ready") % { 'user': user }
+                subject = gettext("%(user)s, your data download is ready") % { 'user': user }
                 mail_user(user, subject, 'misago/emails/data_download', context={
                     'data_download': data_download,
                     'expires_in': settings.MISAGO_USER_DATA_DOWNLOADS_EXPIRE_IN_HOURS,

--- a/misago/users/migrations/0004_default_ranks.py
+++ b/misago/users/migrations/0004_default_ranks.py
@@ -1,5 +1,5 @@
 from django.db import migrations
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 
 from misago.core.utils import slugify
 
@@ -11,17 +11,17 @@ def create_default_ranks(apps, schema_editor):
     Rank = apps.get_model('misago_users', 'Rank')
 
     team = Rank.objects.create(
-        name=ugettext("Forum team"),
-        slug=slugify(ugettext("Forum team")),
-        title=ugettext("Team"),
+        name=gettext("Forum team"),
+        slug=slugify(gettext("Forum team")),
+        title=gettext("Team"),
         css_class='primary',
         is_tab=True,
         order=0,
     )
 
     member = Rank.objects.create(
-        name=ugettext("Members"),
-        slug=slugify(ugettext("Members")),
+        name=gettext("Members"),
+        slug=slugify(gettext("Members")),
         is_default=True,
         order=1,
     )

--- a/misago/users/models/ban.py
+++ b/misago/users/models/ban.py
@@ -3,7 +3,7 @@ import re
 from django.conf import settings
 from django.db import IntegrityError, models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.core import cachebuster
 from misago.users.constants import BANS_CACHEBUSTER

--- a/misago/users/models/datadownload.py
+++ b/misago/users/models/datadownload.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def get_data_upload_to(instance, filename):

--- a/misago/users/models/user.py
+++ b/misago/users/models/user.py
@@ -9,7 +9,7 @@ from django.core.mail import send_mail
 from django.db import IntegrityError, models, transaction
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import get_user_acl
 from misago.acl.models import Role

--- a/misago/users/permissions/account.py
+++ b/misago/users/permissions/account.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.models import Role

--- a/misago/users/permissions/decorators.py
+++ b/misago/users/permissions/decorators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 __all__ = [

--- a/misago/users/permissions/delete.py
+++ b/misago/users/permissions/delete.py
@@ -4,8 +4,8 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean
@@ -84,7 +84,7 @@ def allow_delete_user(user, target):
 
     if newer_than:
         if target.joined_on < timezone.now() - timedelta(days=newer_than):
-            message = ungettext(
+            message = ngettext(
                 "You can't delete users that are members for more than %(days)s day.",
                 "You can't delete users that are members for more than %(days)s days.",
                 newer_than,
@@ -92,7 +92,7 @@ def allow_delete_user(user, target):
             raise PermissionDenied(message % {'days': newer_than})
     if less_posts_than:
         if target.posts > less_posts_than:
-            message = ungettext(
+            message = ngettext(
                 "You can't delete users that made more than %(posts)s post.",
                 "You can't delete users that made more than %(posts)s posts.",
                 less_posts_than,

--- a/misago/users/permissions/moderation.py
+++ b/misago/users/permissions/moderation.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.template.defaultfilters import date as format_date
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean

--- a/misago/users/permissions/profiles.py
+++ b/misago/users/permissions/profiles.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.acl import algebra
 from misago.acl.decorators import return_boolean

--- a/misago/users/profilefields/__init__.py
+++ b/misago/users/profilefields/__init__.py
@@ -4,7 +4,7 @@ import logging
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 

--- a/misago/users/profilefields/default.py
+++ b/misago/users/profilefields/default.py
@@ -1,7 +1,7 @@
 import re
 
 from django.forms import ValidationError
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 
 from . import basefields
 
@@ -74,7 +74,7 @@ class TwitterHandleField(basefields.TextProfileField):
     def clean(self, request, user, data):
         data = data.lstrip('@')
         if data and not re.search('^[A-Za-z0-9_]+$', data):
-            raise ValidationError(ugettext("This is not a valid twitter handle."))
+            raise ValidationError(gettext("This is not a valid twitter handle."))
         return data
 
 

--- a/misago/users/registration.py
+++ b/misago/users/registration.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.mail import mail_user

--- a/misago/users/search.py
+++ b/misago/users/search.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from misago.search import SearchProvider
 
@@ -15,7 +15,7 @@ UserModel = get_user_model()
 
 
 class SearchUsers(SearchProvider):
-    name = ugettext_lazy("Users")
+    name = gettext_lazy("Users")
     icon = 'people'
     url = 'users'
 

--- a/misago/users/serializers/ban.py
+++ b/misago/users/serializers/ban.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.utils import format_plaintext_for_html
 from misago.users.models import Ban

--- a/misago/users/serializers/moderation.py
+++ b/misago/users/serializers/moderation.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from django.contrib.auth import get_user_model
-from django.utils.translation import ungettext
+from django.utils.translation import ngettext
 
 from misago.conf import settings
 
@@ -38,7 +38,7 @@ class ModerateSignatureSerializer(serializers.ModelSerializer):
         length_limit = settings.signature_length_max
         if len(value) > length_limit:
             raise serializers.ValidationError(
-                ungettext(
+                ngettext(
                     "Signature can't be longer than %(limit)s character.",
                     "Signature can't be longer than %(limit)s characters.",
                     length_limit,

--- a/misago/users/serializers/options.py
+++ b/misago/users/serializers/options.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from django.contrib.auth import get_user_model, logout
 from django.contrib.auth.password_validation import validate_password
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.users.online.tracker import clear_tracking

--- a/misago/users/signals.py
+++ b/misago/users/signals.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.dispatch import Signal, receiver
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.conf import settings
 from misago.core.pgutils import chunk_queryset

--- a/misago/users/social/pipeline.py
+++ b/misago/users/social/pipeline.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from social_core.pipeline.partial import partial
 
 from misago.conf import settings

--- a/misago/users/validators.py
+++ b/misago/users/validators.py
@@ -8,8 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import validate_email as validate_email_content
 from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from misago.conf import settings
 
@@ -75,7 +75,7 @@ def validate_username_content(value):
 
 def validate_username_length(value):
     if len(value) < settings.username_length_min:
-        message = ungettext(
+        message = ngettext(
             "Username must be at least %(limit_value)s character long.",
             "Username must be at least %(limit_value)s characters long.",
             settings.username_length_min
@@ -83,7 +83,7 @@ def validate_username_length(value):
         raise ValidationError(message % {'limit_value': settings.username_length_min})
 
     if len(value) > settings.username_length_max:
-        message = ungettext(
+        message = ngettext(
             "Username cannot be longer than %(limit_value)s characters.",
             "Username cannot be longer than %(limit_value)s characters.",
             settings.username_length_max

--- a/misago/users/views/activation.py
+++ b/misago/users/views/activation.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.exceptions import Banned
 from misago.users.bans import get_user_ban

--- a/misago/users/views/admin/bans.py
+++ b/misago/users/views/admin/bans.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 from misago.users.forms.admin import BanForm, SearchBansForm

--- a/misago/users/views/admin/datadownloads.py
+++ b/misago/users/views/admin/datadownloads.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 from misago.users.datadownloads import (

--- a/misago/users/views/admin/ranks.py
+++ b/misago/users/views/admin/ranks.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.views import generic
 from misago.users.forms.admin import RankForm

--- a/misago/users/views/admin/users.py
+++ b/misago/users/views/admin/users.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.db import transaction
 from django.http import JsonResponse
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from misago.admin.auth import start_admin_session
 from misago.admin.views import generic

--- a/misago/users/views/forgottenpassword.py
+++ b/misago/users/views/forgottenpassword.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.core.exceptions import Banned
 from misago.users.bans import get_user_ban

--- a/misago/users/views/options.py
+++ b/misago/users/views/options.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import update_session_auth_hash
 from django.db import IntegrityError
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from misago.users.credentialchange import read_new_credential
 from misago.users.decorators import deny_guests


### PR DESCRIPTION
This PR removes `u` prefix from `gettext` functions now that our master is python 3 only.