### PR TITLE
Made port used for devserver configurable

### DIFF
--- a/dev
+++ b/dev
@@ -9,7 +9,7 @@ NORMAL=$(tput sgr0)
 
 # Required ports
 # Some tasks test for those ports before continuing
-port_django=${PORT_DJANGO:-8000}
+port_django=${MISAGO_DEVSERVER_PORT:-8000}
 port_postgresql=5432
 
 required_ports=($port_postgresql $port_django)

--- a/dev
+++ b/dev
@@ -9,7 +9,7 @@ NORMAL=$(tput sgr0)
 
 # Required ports
 # Some tasks test for those ports before continuing
-port_django=8000
+port_django=${PORT_DJANGO:-8000}
 port_postgresql=5432
 
 required_ports=($port_postgresql $port_django)
@@ -106,7 +106,7 @@ init() {
         nc "127.0.0.1" "$port" < /dev/null
         if [[ $? = "0" ]]; then
             if [[ $port = $port_django ]]; then
-                error "Other application appears to already be running on http://127.0.0.1:8000"
+                error "Other application appears to already be running on http://127.0.0.1:${port_django}"
             elif [[ $port = $port_postgresql ]]; then
                 error "PostgreSQL appears to already be running on the port $port."
                 echo
@@ -145,7 +145,7 @@ after_init_message() {
     echo
     echo "    docker-compose up"
     echo
-    echo "Running server will be available in the browser under the http://127.0.0.1:8000 address."
+    echo "Running server will be available in the browser under the http://127.0.0.1:${port_django} address."
     echo
     echo "Default superuser has been created with this username and password:"
     echo

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     ports:
       # Map port 8000 in the container to port 8000 on the host
       # This way we can access the forum through http://localhost:8000
-      - "${PORT_DJANGO:-8000}:8000"
+      - "${MISAGO_DEVSERVER_PORT:-8000}:8000"
     depends_on:
       - postgres
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     ports:
       # Map port 8000 in the container to port 8000 on the host
       # This way we can access the forum through http://localhost:8000
-      - "8000:8000"
+      - "${PORT_DJANGO:-8000}:8000"
     depends_on:
       - postgres
     tty: true


### PR DESCRIPTION
When I was developing, I found that misago's ports were hardcoded and conflicted with existing ports
So do these changes, allowing from environment variables PORT_DJANGO define the actual exposed port. If there is no defined PORT_DJANGO, port is the default value of 8000