### PR TITLE
Remove misago.core.cache module

### DIFF
--- a/misago/admin/views/index.py
+++ b/misago/admin/views/index.py
@@ -1,5 +1,6 @@
 import requests
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
 from django.http import Http404, JsonResponse
 from django.utils.translation import gettext as _
 from requests.exceptions import RequestException
@@ -7,7 +8,6 @@ from requests.exceptions import RequestException
 from . import render
 from ... import __version__
 from ...conf import settings
-from ...core.cache import cache
 from ...threads.models import Post, Thread
 
 VERSION_CHECK_CACHE_KEY = "misago_version_check"

--- a/misago/categories/models.py
+++ b/misago/categories/models.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.db import models
 from mptt.managers import TreeManager
 from mptt.models import MPTTModel, TreeForeignKey
@@ -6,7 +7,6 @@ from . import PRIVATE_THREADS_ROOT_NAME, THREADS_ROOT_NAME
 from ..acl.cache import clear_acl_cache
 from ..acl.models import BaseRole
 from ..conf import settings
-from ..core.cache import cache
 from ..core.utils import slugify
 from ..threads.threadtypes import trees_map
 

--- a/misago/core/cache.py
+++ b/misago/core/cache.py
@@ -1,8 +1,0 @@
-from django.core.cache import InvalidCacheBackendError
-from django.core.cache import cache as default_cache
-from django.core.cache import caches
-
-try:
-    cache = caches["misago"]
-except InvalidCacheBackendError:
-    cache = default_cache

--- a/misago/legal/models.py
+++ b/misago/legal/models.py
@@ -1,9 +1,9 @@
+from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from ..conf import settings
-from ..core.cache import cache
 
 CACHE_KEY = "misago_agreements"
 

--- a/misago/legal/utils.py
+++ b/misago/legal/utils.py
@@ -1,9 +1,9 @@
 from hashlib import md5
 
 from django.conf import settings
+from django.core.cache import cache
 from django.utils.encoding import force_bytes
 
-from ..core.cache import cache
 from ..markup import common_flavour
 from .models import Agreement, UserAgreement
 


### PR DESCRIPTION
This PR removes misago.core.cache, because the correct way to deploy Misago is as stand-alone service with its own cache server. As such small wrapper for `misago` cache is no longer needed.