### PR TITLE
Re-add pylint to travis checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -19,6 +19,7 @@ disable=
     fixme,
     format,  # delegated to black
     inconsistent-return-statements,
+    invalid-characters-in-docstring,
     invalid-name,
     missing-docstring,
     model-no-explicit-unicode,  # pylint-django
@@ -35,7 +36,10 @@ disable=
     too-many-statements,  # FIXME
     ungrouped-imports,
     unsubscriptable-object,
-    unused-argument
+    unused-argument,
+    wrong-import-order,
+    wrong-spelling-in-comment,
+    wrong-spelling-in-docstring
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
       python: 3.6
       install:
         - pip install -U pip setuptools
+        - python setup.py install
         - pip install black pylint pylint-django
       script:
         - black --check devproject misago && pylint misago --jobs=0 --limit-inference-results=50 --persistent=n

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ jobs:
       python: 3.6
       install:
         - pip install -U pip setuptools
-        - pip install black
+        - pip install black pylint pylint-django
       script:
-        - black --check devproject misago
+        - black --check devproject misago && pylint misago --jobs=0 --limit-inference-results=50 --persistent=n


### PR DESCRIPTION
Experimental PR that re-adds pylint to travis build, but with following tweaks:

- disables spellchecking
- disables persistency
- limits inference results by half (50 from 100)
- enables multiple linting jobs