### PR TITLE
Dev tweaks

### DIFF
--- a/dev
+++ b/dev
@@ -89,7 +89,7 @@ intro() {
     echo "    ${BOLD}bash${NORMAL}              starts bash session inside running Misago container."
     echo "    ${BOLD}run${NORMAL}               runs \"docker-compose run --rm misago\"."
     echo "    ${BOLD}psql${NORMAL}              runs psql connected to development database."
-    echo "    ${BOLD}fmtpy${NORMAL}             runs isort + black on python code."
+    echo "    ${BOLD}pyfmt${NORMAL}             runs isort + black on python code."
     echo
 }
 
@@ -171,11 +171,6 @@ clear() {
 
     devproject_path="$(pwd)/devproject"
 
-    echo "Following files and directories will be deleted:"
-    find $devproject_path/media -mindepth 1 ! -name '.gitignore'
-    find $devproject_path/userdata -mindepth 1 ! -name '.gitignore'
-    echo
-        
     echo "Enter \"y\" to confirm:"
 
     read confirmation
@@ -311,7 +306,7 @@ if [[ $1 ]]; then
         run_psql
     elif [[ $1 = "psql_in_docker" ]]; then
         psql_in_docker
-    elif [[ $1 = "fmtpy" ]]; then
+    elif [[ $1 = "pyfmt" ]]; then
         isort -rc misago
         black devproject misago
     else

--- a/devproject/settings.py
+++ b/devproject/settings.py
@@ -329,6 +329,11 @@ REST_FRAMEWORK = {
 MISAGO_ADDRESS = "http://my-misago-site.com/"
 
 
+# On dev instance, generate only three sizes of avatars instead of default 6 sizes.
+
+MISAGO_AVATARS_SIZES = [400, 200, 100]
+
+
 # PostgreSQL text search configuration to use in searches
 # Defaults to "simple", for list of installed configurations run "\dF" in "psql".
 # Standard configs as of PostgreSQL 9.5 are: dutch, english, finnish, french,


### PR DESCRIPTION
This PR tweaks some dev things:

- `./dev fmtpy` has been changed to `./dev pyfmt`
- `./dev clear` no longer lists files that will be deleted (this took a long time to if dev generated fake data)
- Number of user avatar sizes stored by Misago was limited to three: 400, 200 and 100.