### PR TITLE
Fix session filters is None from request session

### DIFF
--- a/misago/admin/tests/test_generic_admin_list_view.py
+++ b/misago/admin/tests/test_generic_admin_list_view.py
@@ -37,3 +37,12 @@ def test_unicode_is_preserved_in_redirect_querystring(admin_client):
 def test_view_is_not_redirecting_if_flag_is_set_in_querystring(admin_client):
     response = admin_client.get("%s?redirected=1" % list_link)
     assert response.status_code == 200
+
+
+def test_view_session_filter_is_none(admin_client):
+    response = admin_client.get("%s?set_filters=1&rank=1" % list_link)
+    assert response.status_code == 302
+    response = admin_client.get("%s?set_filters=0" % list_link)
+    assert response.status_code == 302
+    response = admin_client.get("%s" % list_link)
+    assert response.status_code == 200

--- a/misago/admin/tests/test_generic_admin_list_view.py
+++ b/misago/admin/tests/test_generic_admin_list_view.py
@@ -39,10 +39,10 @@ def test_view_is_not_redirecting_if_flag_is_set_in_querystring(admin_client):
     assert response.status_code == 200
 
 
-def test_view_session_filter_is_none(admin_client):
+def test_restoring_filters_from_session_handles_filters_entry_being_none(admin_client):
     response = admin_client.get("%s?set_filters=1&rank=1" % list_link)
     assert response.status_code == 302
     response = admin_client.get("%s?set_filters=0" % list_link)
     assert response.status_code == 302
-    response = admin_client.get("%s" % list_link)
+    response = admin_client.get("%s?redirected=1" % list_link)
     assert response.status_code == 200

--- a/misago/admin/views/generic/list.py
+++ b/misago/admin/views/generic/list.py
@@ -134,7 +134,7 @@ class ListView(AdminView):
             if request.GET.get("set_filters"):
                 # Force store filters in session
                 session_key = self.filters_session_key
-                request.session[session_key] = context["active_filters"] or {}
+                request.session[session_key] = context["active_filters"]
                 refresh_querystring = True
 
             if context["active_filters"] and not filtering_methods["GET"]:

--- a/misago/admin/views/generic/list.py
+++ b/misago/admin/views/generic/list.py
@@ -200,7 +200,8 @@ class ListView(AdminView):
         return self.clean_filtering_data(form.cleaned_data)
 
     def get_filters_from_session(self, request, search_form):
-        session_filters = request.session.get(self.filters_session_key, {})
+        session_filters = request.session.get(
+            self.filters_session_key, {}) or {}
         form = search_form(session_filters)
         form.is_valid()
         return self.clean_filtering_data(form.cleaned_data)

--- a/misago/admin/views/generic/list.py
+++ b/misago/admin/views/generic/list.py
@@ -200,8 +200,7 @@ class ListView(AdminView):
         return self.clean_filtering_data(form.cleaned_data)
 
     def get_filters_from_session(self, request, search_form):
-        session_filters = request.session.get(
-            self.filters_session_key, {}) or {}
+        session_filters = request.session.get(self.filters_session_key) or {}
         form = search_form(session_filters)
         form.is_valid()
         return self.clean_filtering_data(form.cleaned_data)

--- a/misago/admin/views/generic/list.py
+++ b/misago/admin/views/generic/list.py
@@ -134,7 +134,7 @@ class ListView(AdminView):
             if request.GET.get("set_filters"):
                 # Force store filters in session
                 session_key = self.filters_session_key
-                request.session[session_key] = context["active_filters"]
+                request.session[session_key] = context["active_filters"] or {}
                 refresh_querystring = True
 
             if context["active_filters"] and not filtering_methods["GET"]:


### PR DESCRIPTION
If get session filters is `None` from request session, the search form will be raise no attribute 'cleaned_data' exception.