### PR TITLE
Don't read imported asset into memory

### DIFF
--- a/misago/themes/admin/importer.py
+++ b/misago/themes/admin/importer.py
@@ -43,8 +43,7 @@ def import_theme(name, parent, zipfile):
         try:
             create_css_from_manifest(theme_dir, theme, cleaned_manifest["css"])
             create_media_from_manifest(theme_dir, theme, cleaned_manifest["media"])
-        except Exception as e:
-            print(e)
+        except Exception:
             theme.delete()
             raise InvalidThemeManifest()
         else:

--- a/misago/themes/admin/importer.py
+++ b/misago/themes/admin/importer.py
@@ -3,7 +3,7 @@ import os
 from tempfile import TemporaryDirectory
 from zipfile import BadZipFile, ZipFile
 
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.uploadedfile import UploadedFile
 from django.utils.translation import gettext as _, gettext_lazy
 
 from ..models import Theme
@@ -43,7 +43,8 @@ def import_theme(name, parent, zipfile):
         try:
             create_css_from_manifest(theme_dir, theme, cleaned_manifest["css"])
             create_media_from_manifest(theme_dir, theme, cleaned_manifest["media"])
-        except Exception:
+        except Exception as e:
+            print(e)
             theme.delete()
             raise InvalidThemeManifest()
         else:
@@ -196,8 +197,11 @@ def create_css_from_manifest(tmp_dir, theme, manifest):
             theme.css.create(**item, order=theme.css.count())
         else:
             with open(item["path"], "rb") as fp:
-                file_obj = SimpleUploadedFile(
-                    item["name"], fp.read(), content_type="text/css"
+                file_obj = UploadedFile(
+                    fp,
+                    name=item["name"],
+                    content_type="text/css",
+                    size=os.path.getsize(item["path"]),
                 )
                 create_css(theme, file_obj)
 
@@ -205,7 +209,10 @@ def create_css_from_manifest(tmp_dir, theme, manifest):
 def create_media_from_manifest(tmp_dir, theme, manifest):
     for item in manifest:
         with open(item["path"], "rb") as fp:
-            file_obj = SimpleUploadedFile(
-                item["name"], fp.read(), content_type=item["type"]
+            file_obj = UploadedFile(
+                fp,
+                name=item["name"],
+                content_type=item["type"],
+                size=os.path.getsize(item["path"]),
             )
             create_media(theme, file_obj)


### PR DESCRIPTION
This PR improves theme import a little by not reading entire asset file into memory when asset is added to newly created theme.