### PR TITLE
admincp: fix Rank is_tab checkbox - incorrect value, form field misalignment

### DIFF
--- a/misago/templates/misago/admin/ranks/form.html
+++ b/misago/templates/misago/admin/ranks/form.html
@@ -57,7 +57,7 @@ class="form-horizontal"
       <legend>{% trans "Display and visibility" %}</legend>
 
       {% form_row form.css_class label_class field_class %}
-      {% form_row form.is_tab "col-md-offset-3" field_class %}
+      {% form_row form.is_tab "col-md-3" field_class %}
 
     </fieldset>
   {% endwith %}

--- a/misago/users/forms/admin.py
+++ b/misago/users/forms/admin.py
@@ -418,7 +418,7 @@ class RankForm(forms.ModelForm):
             "Optional css class added to content belonging to this rank owner."
         ),
     )
-    is_tab = forms.BooleanField(
+    is_tab = YesNoSwitch(
         label=_("Give rank dedicated tab on users list"),
         required=False,
         help_text=_(


### PR DESCRIPTION
From admincp, the Rank is_tab field is broken

* is_tab: isn't displaying correct value -- eg. is_tab=True should have is_tab field checked
* is_tab form field misalignment

This PR fixes the issues above.