### PR TITLE
Add application HealthCheck

### DIFF
--- a/misago/healthcheck/urls.py
+++ b/misago/healthcheck/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import url
+
+from .views import healthcheck
+
+urlpatterns = [url(r"^healthcheck/$", healthcheck, name="healthcheck")]

--- a/misago/healthcheck/views.py
+++ b/misago/healthcheck/views.py
@@ -1,0 +1,7 @@
+from django.http import JsonResponse
+from rest_framework.decorators import action
+
+
+@action(methods=["get"], detail=True)
+def healthcheck(request):
+    return JsonResponse({"status": "OK"})

--- a/misago/urls.py
+++ b/misago/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r"^", include("misago.threads.urls")),
     url(r"^", include("misago.search.urls")),
     url(r"^", include("misago.socialauth.urls")),
+    url(r"^", include("misago.healthcheck.urls")),
     # default robots.txt
     url(
         r"^robots.txt$",


### PR DESCRIPTION
## What

At the current state of the application, it's kind of pointless to have
any sort of healthcheck endpoint present. This would however become
really useful, once we are considering running Misago on a self-healing
infrastructure, such as Kubernetes.

K8s has a functionality monitoring the [readiness and liveliness][1]
probes, expecting everything to be functioning correctly. If an
unexpected status is exposed via URL, it will try to kill the
application causing a recreation with hopefully healthy state.

The proposed addition, will check the django runtime, including the
database connection which is being touched by a django middleware before
the view is rendered. I hope, this will grow over time, with fields such
as `cache` or `queue`.

[1]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/

## How to review

- Code review - I don't python.
- Run unit tests - make sure nothing has been broken
- Run `docker-compose up`
- Visit `http://127.0.0.1:8000/healthcheck` - expect success
- Either trust it will do the right upon failure, or change the boolean in code; or change DB password in flight
