### PR TITLE
Replace chunk_queryset() util with server-side cursor

### DIFF
--- a/misago/core/pgutils.py
+++ b/misago/core/pgutils.py
@@ -1,9 +1,0 @@
-def chunk_queryset(queryset, chunk_size=20):
-    ordered_queryset = queryset.order_by("-pk")  # bias to newest items first
-    chunk = ordered_queryset[:chunk_size]
-    while chunk:
-        last_pk = None
-        for item in chunk:
-            last_pk = item.pk
-            yield item
-        chunk = ordered_queryset.filter(pk__lt=last_pk)[:chunk_size]

--- a/misago/core/tests/test_chunk_queryset.py
+++ b/misago/core/tests/test_chunk_queryset.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
 from ...cache.models import CacheVersion
-from ..pgutils import chunk_queryset
 
 
 class ChunkQuerysetTest(TestCase):
@@ -21,7 +20,7 @@ class ChunkQuerysetTest(TestCase):
 
         with self.assertNumQueries(11):
             queryset = CacheVersion.objects.order_by("cache")
-            for obj in chunk_queryset(queryset, chunk_size=5):
+            for obj in queryset.iterator(chunk_size=5):
                 chunked_pks.append(obj.pk)
 
         self.assertEqual(chunked_pks, self.items_pks)
@@ -30,7 +29,7 @@ class ChunkQuerysetTest(TestCase):
         """chunk_queryset utility chunks queryset in delete action"""
         with self.assertNumQueries(61):
             queryset = CacheVersion.objects.all()
-            for obj in chunk_queryset(queryset, chunk_size=5):
+            for obj in queryset.iterator(chunk_size=5):
                 obj.delete()
 
         self.assertEqual(CacheVersion.objects.count(), 0)

--- a/misago/faker/management/commands/createfakehistory.py
+++ b/misago/faker/management/commands/createfakehistory.py
@@ -238,7 +238,7 @@ class Command(BaseCommand):
         self.stdout.write("\nSynchronizing threads...")
         start_time = time.time()
 
-        for thread in Thread.objects.all().iterator(chunk_size=20)):
+        for thread in Thread.objects.all().iterator(chunk_size=20):
             thread.synchronize()
             thread.save()
 

--- a/misago/faker/management/commands/createfakehistory.py
+++ b/misago/faker/management/commands/createfakehistory.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from faker import Factory
 
 from ....categories.models import Category
-from ....core.pgutils import chunk_queryset
 from ....threads.checksums import update_post_checksum
 from ....threads.models import Thread
 from ....users.models import Rank
@@ -239,7 +238,7 @@ class Command(BaseCommand):
         self.stdout.write("\nSynchronizing threads...")
         start_time = time.time()
 
-        for thread in chunk_queryset(Thread.objects.all()):
+        for thread in Thread.objects.all().iterator(chunk_size=20)):
             thread.synchronize()
             thread.save()
 

--- a/misago/faker/management/commands/createfakeposts.py
+++ b/misago/faker/management/commands/createfakeposts.py
@@ -7,7 +7,6 @@ from faker import Factory
 
 from ....categories.models import Category
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 from ....threads.models import Thread
 from ...posts import get_fake_hidden_post, get_fake_post, get_fake_unapproved_post
 
@@ -62,7 +61,7 @@ class Command(BaseCommand):
             created_posts += 1
             show_progress(self, created_posts, items_to_create, start_time)
 
-        for thread in chunk_queryset(Thread.objects.all()):
+        for thread in Thread.objects.all().iterator(chunk_size=20):
             thread.synchronize()
             thread.save()
 

--- a/misago/threads/management/commands/clearattachments.py
+++ b/misago/threads/management/commands/clearattachments.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 
 from ....conf.shortcuts import get_dynamic_settings
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 from ...models import Attachment
 
 
@@ -33,7 +32,7 @@ class Command(BaseCommand):
         show_progress(self, cleared_count, attachments_to_sync)
         start_time = time.time()
 
-        for attachment in chunk_queryset(queryset):
+        for attachment in queryset.iterator(chunk_size=20):
             attachment.delete()
 
             cleared_count += 1

--- a/misago/threads/management/commands/rebuildpostssearch.py
+++ b/misago/threads/management/commands/rebuildpostssearch.py
@@ -3,7 +3,6 @@ import time
 from django.core.management.base import BaseCommand
 
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 from ...models import Post
 
 
@@ -26,7 +25,7 @@ class Command(BaseCommand):
         start_time = time.time()
 
         queryset = Post.objects.select_related("thread").filter(is_event=False)
-        for post in chunk_queryset(queryset):
+        for post in queryset.iterator(chunk_size=20):
             if post.id == post.thread.first_post_id:
                 post.set_search_document(post.thread.title)
             else:

--- a/misago/threads/management/commands/synchronizethreads.py
+++ b/misago/threads/management/commands/synchronizethreads.py
@@ -3,7 +3,6 @@ import time
 from django.core.management.base import BaseCommand
 
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 from ...models import Thread
 
 
@@ -25,7 +24,7 @@ class Command(BaseCommand):
         show_progress(self, synchronized_count, threads_to_sync)
         start_time = time.time()
 
-        for thread in chunk_queryset(Thread.objects.all()):
+        for thread in Thread.objects.all().iterator(chunk_size=20):
             thread.synchronize()
             thread.save()
 

--- a/misago/threads/management/commands/updatepostschecksums.py
+++ b/misago/threads/management/commands/updatepostschecksums.py
@@ -3,7 +3,6 @@ import time
 from django.core.management.base import BaseCommand
 
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 from ...checksums import update_post_checksum
 from ...models import Post
 
@@ -27,7 +26,7 @@ class Command(BaseCommand):
         start_time = time.time()
 
         queryset = Post.objects.filter(is_event=False)
-        for post in chunk_queryset(queryset):
+        for post in queryset.iterator(chunk_size=20):
             update_post_checksum(post)
             post.save(update_fields=["checksum"])
 

--- a/misago/threads/signals.py
+++ b/misago/threads/signals.py
@@ -8,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from ..categories.models import Category
 from ..categories.signals import delete_category_content, move_category_content
-from ..core.pgutils import chunk_queryset
 from ..users.signals import (
     anonymize_user_data,
     archive_user_data,
@@ -86,18 +85,18 @@ def delete_user_threads(sender, **kwargs):
     recount_categories = set()
     recount_threads = set()
 
-    for post in chunk_queryset(sender.liked_post_set):
+    for post in sender.liked_post_set.iterator(chunk_size=20):
         cleaned_likes = list(filter(lambda i: i["id"] != sender.id, post.last_likes))
         if cleaned_likes != post.last_likes:
             post.last_likes = cleaned_likes
             post.save(update_fields=["last_likes"])
 
-    for thread in chunk_queryset(sender.thread_set):
+    for thread in sender.thread_set.iterator(chunk_size=20):
         recount_categories.add(thread.category_id)
         with transaction.atomic():
             thread.delete()
 
-    for post in chunk_queryset(sender.post_set):
+    for post in sender.post_set.iterator(chunk_size=20):
         recount_categories.add(post.category_id)
         recount_threads.add(post.thread_id)
         with transaction.atomic():
@@ -105,7 +104,7 @@ def delete_user_threads(sender, **kwargs):
 
     if recount_threads:
         changed_threads_qs = Thread.objects.filter(id__in=recount_threads)
-        for thread in chunk_queryset(changed_threads_qs):
+        for thread in changed_threads_qs.iterator(chunk_size=20):
             thread.synchronize()
             thread.save()
 
@@ -118,7 +117,7 @@ def delete_user_threads(sender, **kwargs):
 @receiver(archive_user_data)
 def archive_user_attachments(sender, archive=None, **kwargs):
     queryset = sender.attachment_set.order_by("id")
-    for attachment in chunk_queryset(queryset):
+    for attachment in queryset.iterator(size_size=20):
         archive.add_model_file(
             attachment.file,
             prefix=attachment.uploaded_on.strftime("%H%M%S-file"),
@@ -139,7 +138,7 @@ def archive_user_attachments(sender, archive=None, **kwargs):
 @receiver(archive_user_data)
 def archive_user_posts(sender, archive=None, **kwargs):
     queryset = sender.post_set.order_by("id")
-    for post in chunk_queryset(queryset):
+    for post in queryset.iterator(chunk_size=20):
         item_name = post.posted_on.strftime("%H%M%S-post")
         archive.add_text(item_name, post.parsed, date=post.posted_on)
 
@@ -147,11 +146,11 @@ def archive_user_posts(sender, archive=None, **kwargs):
 @receiver(archive_user_data)
 def archive_user_posts_edits(sender, archive=None, **kwargs):
     queryset = PostEdit.objects.filter(post__poster=sender).order_by("id")
-    for post_edit in chunk_queryset(queryset):
+    for post_edit in queryset.iterator(chunk_size=20):
         item_name = post_edit.edited_on.strftime("%H%M%S-post-edit")
         archive.add_text(item_name, post_edit.edited_from, date=post_edit.edited_on)
     queryset = sender.postedit_set.exclude(id__in=queryset.values("id")).order_by("id")
-    for post_edit in chunk_queryset(queryset):
+    for post_edit in queryset.iterator(chunk_size=20):
         item_name = post_edit.edited_on.strftime("%H%M%S-post-edit")
         archive.add_text(item_name, post_edit.edited_from, date=post_edit.edited_on)
 
@@ -159,7 +158,7 @@ def archive_user_posts_edits(sender, archive=None, **kwargs):
 @receiver(archive_user_data)
 def archive_user_polls(sender, archive=None, **kwargs):
     queryset = sender.poll_set.order_by("id")
-    for poll in chunk_queryset(queryset):
+    for poll in queryset.iterator(chunk_size=20):
         item_name = poll.posted_on.strftime("%H%M%S-poll")
         archive.add_dict(
             item_name,
@@ -181,13 +180,13 @@ def anonymize_user_in_events(sender, **kwargs):
         event_context__user__id=sender.id,
     )
 
-    for event in chunk_queryset(queryset):
+    for event in queryset.iterator(chunk_size=20):
         anonymize_event(sender, event)
 
 
 @receiver([anonymize_user_data])
 def anonymize_user_in_likes(sender, **kwargs):
-    for post in chunk_queryset(sender.liked_post_set):
+    for post in sender.liked_post_set.iterator(chunk_size=20):
         anonymize_post_last_likes(sender, post)
 
 
@@ -236,7 +235,7 @@ def update_usernames(sender, **kwargs):
 @receiver(pre_delete, sender=get_user_model())
 def remove_unparticipated_private_threads(sender, **kwargs):
     threads_qs = kwargs["instance"].privatethread_set.all()
-    for thread in chunk_queryset(threads_qs):
+    for thread in threads_qs.iterator(chunk_size=20):
         if thread.participants.count() == 1:
             with transaction.atomic():
                 thread.delete()

--- a/misago/users/admin/views/users.py
+++ b/misago/users/admin/views/users.py
@@ -10,7 +10,6 @@ from ....admin.auth import authorize_admin
 from ....admin.views import generic
 from ....categories.models import Category
 from ....core.mail import mail_users
-from ....core.pgutils import chunk_queryset
 from ....threads.models import Thread
 from ...avatars.dynamic import set_avatar as set_dynamic_avatar
 from ...datadownloads import request_user_data_download, user_has_data_download_request

--- a/misago/users/management/commands/deleteinactiveusers.py
+++ b/misago/users/management/commands/deleteinactiveusers.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from ....conf.shortcuts import get_dynamic_settings
-from ....core.pgutils import chunk_queryset
 
 User = get_user_model()
 
@@ -31,7 +30,7 @@ class Command(BaseCommand):
             requires_activation__gt=User.ACTIVATION_NONE, joined_on__lt=joined_on_cutoff
         )
 
-        for user in chunk_queryset(queryset):
+        for user in queryset.iterator(chunk_size=20):
             user.delete(anonymous_username=settings.anonymous_username)
             users_deleted += 1
 

--- a/misago/users/management/commands/deletemarkedusers.py
+++ b/misago/users/management/commands/deletemarkedusers.py
@@ -2,7 +2,6 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
 from ....conf.shortcuts import get_dynamic_settings
-from ....core.pgutils import chunk_queryset
 from ...permissions import can_delete_own_account
 
 User = get_user_model()
@@ -20,7 +19,7 @@ class Command(BaseCommand):
 
         queryset = User.objects.filter(is_deleting_account=True)
 
-        for user in chunk_queryset(queryset):
+        for user in queryset.iterator(chunk_size=20):
             if can_delete_own_account(settings, user, user):
                 user.delete(anonymous_username=settings.anonymous_username)
                 users_deleted += 1

--- a/misago/users/management/commands/deleteprofilefield.py
+++ b/misago/users/management/commands/deleteprofilefield.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from ....core.pgutils import chunk_queryset
 
 User = get_user_model()
 
@@ -22,7 +21,7 @@ class Command(BaseCommand):
 
         queryset = User.objects.filter(profile_fields__has_keys=[fieldname])
 
-        for user in chunk_queryset(queryset):
+        for user in queryset.iterator(chunk_size=20):
             if fieldname in user.profile_fields.keys():
                 user.profile_fields.pop(fieldname)
                 user.save(update_fields=["profile_fields"])

--- a/misago/users/management/commands/expireuserdatadownloads.py
+++ b/misago/users/management/commands/expireuserdatadownloads.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from ....core.pgutils import chunk_queryset
 from ...datadownloads import expire_user_data_download
 from ...models import DataDownload
 
@@ -16,7 +15,7 @@ class Command(BaseCommand):
             status=DataDownload.STATUS_READY, expires_on__lte=timezone.now()
         )
 
-        for data_download in chunk_queryset(queryset):
+        for data_download in queryset.iterator(chunk_size=20):
             expire_user_data_download(data_download)
             downloads_expired += 1
 

--- a/misago/users/management/commands/listusedprofilefields.py
+++ b/misago/users/management/commands/listusedprofilefields.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from ....core.pgutils import chunk_queryset
 
 User = get_user_model()
 
@@ -12,7 +11,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         keys = {}
 
-        for user in chunk_queryset(User.objects.all()):
+        for user in User.objects.all().iterator(chunk_size=20):
             for key in user.profile_fields:
                 keys.setdefault(key, 0)
                 keys[key] += 1

--- a/misago/users/management/commands/populateonlinetracker.py
+++ b/misago/users/management/commands/populateonlinetracker.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from ....core.pgutils import chunk_queryset
 from ...models import Online
 
 User = get_user_model()
@@ -13,7 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         entries_created = 0
         queryset = User.objects.filter(online_tracker__isnull=True)
-        for user in chunk_queryset(queryset):
+        for user in queryset.iterator(chunk_size=20):
             Online.objects.create(user=user, last_click=user.last_login)
             entries_created += 1
 

--- a/misago/users/management/commands/prepareuserdatadownloads.py
+++ b/misago/users/management/commands/prepareuserdatadownloads.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext
 from ....conf import settings
 from ....conf.shortcuts import get_dynamic_settings
 from ....core.mail import mail_user
-from ....core.pgutils import chunk_queryset
 from ...datadownloads import prepare_user_data_download
 from ...models import DataDownload
 
@@ -32,7 +31,7 @@ class Command(BaseCommand):
         downloads_prepared = 0
         queryset = DataDownload.objects.select_related("user")
         queryset = queryset.filter(status=DataDownload.STATUS_PENDING)
-        for data_download in chunk_queryset(queryset):
+        for data_download in queryset.iterator(chunk_size=20):
             if prepare_user_data_download(data_download, expires_in, logger):
                 user = data_download.user
                 subject = gettext("%(user)s, your data download is ready") % {

--- a/misago/users/management/commands/synchronizeusers.py
+++ b/misago/users/management/commands/synchronizeusers.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 
 from ....categories.models import Category
 from ....core.management.progressbar import show_progress
-from ....core.pgutils import chunk_queryset
 
 User = get_user_model()
 
@@ -30,7 +29,7 @@ class Command(BaseCommand):
         show_progress(self, synchronized_count, users_to_sync)
         start_time = time.time()
 
-        for user in chunk_queryset(User.objects.all()):
+        for user in User.objects.all().iterator(chunk_size=20):
             user.threads = user.thread_set.filter(
                 category__in=categories, is_hidden=False, is_unapproved=False
             ).count()


### PR DESCRIPTION
# Replace chunk_queryset() util with server-side cursor #1230 

## Motivation
<blockquote>
Currently Misago uses chunk_queryset utility that iterates on queryset in chunks of specified length, but this task can be easily replaced with queryset.iterator() which on PostgreSQL should use chunking in database.
</blockquote>

## Solution

Change function util `chunk_queryset` to __[iterator()](https://docs.djangoproject.com/en/2.2/ref/models/querysets/#iterator)__ method.