### PR TITLE
Use gender agnostic pronouns in help text

### DIFF
--- a/misago/threads/permissions/privatethreads.py
+++ b/misago/threads/permissions/privatethreads.py
@@ -43,7 +43,7 @@ class PermissionsForm(forms.Form):
     can_add_everyone_to_private_threads = YesNoSwitch(
         label=_("Can add everyone to threads"),
         help_text=_(
-            "Allows user to add users that are blocking him to private threads."
+            "Allows user to add users that are blocking them to private threads."
         ),
     )
     can_report_private_threads = YesNoSwitch(

--- a/misago/threads/tests/test_privatethread_patch_api.py
+++ b/misago/threads/tests/test_privatethread_patch_api.py
@@ -170,7 +170,7 @@ class PrivateThreadAddParticipantApiTests(PrivateThreadPatchApiTestCase):
     def test_add_user(self):
         """
         adding user to thread add user to thread as participant,
-        sets event and emails him
+        sets event and emails them
         """
         ThreadParticipant.objects.set_owner(self.thread, self.user)
 
@@ -323,7 +323,7 @@ class PrivateThreadRemoveParticipantApiTests(PrivateThreadPatchApiTestCase):
         )
 
     def test_user_leave_thread(self):
-        """api allows user to remove himself from thread"""
+        """api allows user to remove themself from thread"""
         ThreadParticipant.objects.set_owner(self.thread, self.other_user)
         ThreadParticipant.objects.add_participants(self.thread, [self.user])
 
@@ -360,7 +360,7 @@ class PrivateThreadRemoveParticipantApiTests(PrivateThreadPatchApiTestCase):
         self.assertEqual(self.user.subscription_set.count(), 0)
 
     def test_user_leave_closed_thread(self):
-        """api allows user to remove himself from closed thread"""
+        """api allows user to remove themself from closed thread"""
         ThreadParticipant.objects.set_owner(self.thread, self.other_user)
         ThreadParticipant.objects.add_participants(self.thread, [self.user])
 


### PR DESCRIPTION
Super quick and minor change to use gender-agnostic pronouns in some of the help text (mostly in tests).