### PR TITLE
Remove unused pagination from threads lists templates

### DIFF
--- a/misago/templates/misago/threadslist/base.html
+++ b/misago/templates/misago/threadslist/base.html
@@ -43,7 +43,6 @@
         <div class="threads-list ui-ready">
           {% block threads-list %}
             <ul class="list-group" itemscope itemtype="http://schema.org/ItemList">
-              <meta itemprop="numberOfItems" content="{{ paginator.count }}">
               <meta itemprop="itemListOrder" content="http://schema.org/ItemListOrderDescending">
               {% for thread in threads %}
                 {% block thread %}

--- a/misago/templates/misago/threadslist/category.html
+++ b/misago/templates/misago/threadslist/category.html
@@ -4,13 +4,7 @@
 
 {% block title %}
   {% if list_name %}
-    {% if paginator.page > 1 %}
-      {{ list_name }} ({% blocktrans with page=paginator.page %}page: {{ page }}{% endblocktrans %}) | {{ category }} | {{ block.super }}
-    {% else %}
-      {{ list_name }} | {{ category }} | {{ block.super }}
-    {% endif %}
-  {% elif paginator.page > 1 %}
-    {{ category }} ({% blocktrans with page=paginator.page %}page: {{ page }}{% endblocktrans %}) | {{ block.super }}
+    {{ list_name }} | {{ category }} | {{ block.super }}
   {% else %}
     {{ category }} | {{ block.super }}
   {% endif %}

--- a/misago/templates/misago/threadslist/private_threads.html
+++ b/misago/templates/misago/threadslist/private_threads.html
@@ -4,13 +4,7 @@
 
 {% block title %}
 {% if list_name %}
-  {% if paginator.page > 1 %}
-    {{ list_name }} ({% blocktrans with page=paginator.page %}page: {{ page }}{% endblocktrans %}) | {{ category }} | {{ block.super }}
-  {% else %}
-    {{ list_name }} | {{ category }} | {{ block.super }}
-  {% endif %}
-{% elif paginator.page > 1 %}
-  {{ category }} ({% blocktrans with page=paginator.page %}page: {{ page }}{% endblocktrans %}) | {{ block.super }}
+  {{ list_name }} | {{ category }} | {{ block.super }}
 {% else %}
   {{ category }} | {{ block.super }}
 {% endif %}

--- a/misago/templates/misago/threadslist/thread.html
+++ b/misago/templates/misago/threadslist/thread.html
@@ -1,4 +1,4 @@
-{% load i18n misago_avatars misago_capture %}
+{% load i18n misago_absoluteurl misago_avatars misago_capture %}
 <li class="list-group-item {% if thread.category.css_class %}list-group-category-has-flavor list-group-item-category-{{ thread.category.css_class }}{% endif %} thread-{{ thread.is_read|yesno:'read,new' }}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
 
   <div class="thread-details-top">
@@ -212,5 +212,8 @@
       </div>
     </div>
   </div>
-  <meta itemprop="position" content="{{ paginator.before|add:forloop.counter }}">
+  
+  <meta itemprop="position" content="{{ list_page.start|add:forloop.counter }}">
+  <meta itemprop="url" content="{% absoluteurl thread.get_absolute_url %}">
+  <meta itemprop="name" content="{{ thread.title }}">
 </li>

--- a/misago/templates/misago/threadslist/threads.html
+++ b/misago/templates/misago/threadslist/threads.html
@@ -3,7 +3,7 @@
 
 
 {% block title %}
-  {% if THREADS_ON_INDEX and paginator.page == 1 %}
+  {% if THREADS_ON_INDEX %}
     {% if list_name %}
       {{ list_name }} | {{ block.super }}
     {% else %}
@@ -12,8 +12,6 @@
   {% else %}
     {% if list_name %}
       {{ list_name }} | {% trans "Threads" %} | {{ block.super }}
-    {% elif paginator.page > 1 %}
-      {% trans "Threads" %} ({% blocktrans with page=paginator.page %}page: {{ page }}{% endblocktrans %}) | {{ block.super }}
     {% else %}
       {% trans "Threads" %} | {{ block.super }}
     {% endif %}


### PR DESCRIPTION
This PR removes pagination from threads lists templates, since in Misago 0.20 threads lists moved to cursor pagination.

This PR also fixes faulty logic producing incorrect page title of threads list on index page.

## TODO

* [x] Fix title creation
* [x] Remove schema.org data from threads lists