### PR TITLE
Cache only PyPI response not entire version check

### DIFF
--- a/misago/graphql/admin/tests/test_version_check.py
+++ b/misago/graphql/admin/tests/test_version_check.py
@@ -5,7 +5,7 @@ from ariadne import gql
 from requests.exceptions import RequestException
 
 from .... import __version__
-from ..versioncheck import CACHE_KEY, CACHE_LENGTH, resolve_version
+from ..versioncheck import CACHE_KEY, CACHE_LENGTH, resolve_version, get_latest_version
 
 test_query = gql("{ version { status message description } }")
 
@@ -78,4 +78,4 @@ def test_version_check_cache_is_returned_when_set(mocker):
     mocker.patch("misago.graphql.admin.versioncheck.__released__", True)
     mocker.patch("django.core.cache.cache.get", return_value={"status": "TEST"})
     api_mock = mock_requests_get(mocker, Mock())
-    assert resolve_version() == {"status": "TEST"}
+    assert get_latest_version() == {"status": "TEST"}

--- a/misago/graphql/admin/versioncheck.py
+++ b/misago/graphql/admin/versioncheck.py
@@ -18,12 +18,7 @@ def resolve_version(*_):
     if not __released__:
         return get_unreleased_error()
 
-    data = cache.get(CACHE_KEY)
-    if not data:
-        data = check_version_with_api()
-        if data["status"] != Status.WARNING:
-            cache.set(CACHE_KEY, data, CACHE_LENGTH)
-    return data
+    return check_version_with_api()
 
 
 def get_unreleased_error():
@@ -54,10 +49,16 @@ def check_version_with_api():
 
 
 def get_latest_version():
-    api_url = "https://pypi.org/pypi/Misago/json"
-    r = requests.get(api_url)
-    r.raise_for_status()
-    return r.json()["info"]["version"]
+    data = cache.get(CACHE_KEY)
+
+    if not data:
+        api_url = "https://pypi.org/pypi/Misago/json"
+        r = requests.get(api_url)
+        r.raise_for_status()
+        data = r.json()["info"]["version"]
+        cache.set(CACHE_KEY, data, CACHE_LENGTH)
+
+    return data
 
 
 def compare_versions(current, latest):


### PR DESCRIPTION
Resolves #1291 

I _think_ this is the right set of changes that need to be made. I did have to modify one of the tests because the cache response is in the `get_latest_version` function, a little deeper in the stack.

I wasn't able to get the check working in my local dev instance, but the tests are passing. 