### PR TITLE
Add hooks for posts/registration validation and search filters

### DIFF
--- a/misago/core/tests/test_context_processors_hook.py
+++ b/misago/core/tests/test_context_processors_hook.py
@@ -1,0 +1,8 @@
+from ..context_processors import hooks
+
+
+def test_context_processors_hook_can_inject_context(mocker):
+    plugin = mocker.Mock(return_value={"plugin": True})
+    mocker.patch("misago.core.context_processors.context_processors_hooks", [plugin])
+    context = hooks(None)
+    assert context == {"plugin": True}

--- a/misago/hooks.py
+++ b/misago/hooks.py
@@ -1,3 +1,7 @@
 apipatterns = []
 urlpatterns = []
 context_processors = []
+
+new_registrations_validators = []
+post_search_filters = []
+post_validators = []

--- a/misago/threads/filtersearch.py
+++ b/misago/threads/filtersearch.py
@@ -1,5 +1,6 @@
 from django.utils.module_loading import import_string
 
+from .. import hooks
 from ..conf import settings
 
 filters_list = settings.MISAGO_POST_SEARCH_FILTERS
@@ -8,6 +9,10 @@ SEARCH_FILTERS = list(map(import_string, filters_list))
 
 def filter_search(search, filters=None):
     filters = filters or SEARCH_FILTERS
+
     for search_filter in filters:
         search = search_filter(search) or search
+    for search_filter in hooks.post_search_filters:
+        search = search_filter(search) or search
+
     return search

--- a/misago/threads/validators.py
+++ b/misago/threads/validators.py
@@ -3,6 +3,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 
+from .. import hooks
 from ..categories import THREADS_ROOT_NAME
 from ..categories.models import Category
 from ..categories.permissions import can_browse_category, can_see_category
@@ -107,6 +108,8 @@ def validate_post(context, data, validators=None):
     validators = validators or POST_VALIDATORS
 
     for validator in validators:
+        data = validator(context, data) or data
+    for validator in hooks.post_validators:
         data = validator(context, data) or data
 
     return data

--- a/misago/users/validators.py
+++ b/misago/users/validators.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from requests.exceptions import RequestException
 
+from .. import hooks
 from ..conf import settings
 from .bans import get_email_ban, get_username_ban
 
@@ -157,6 +158,9 @@ def raise_validation_error(*_):
 
 def validate_new_registration(request, cleaned_data, add_error=None, validators=None):
     validators = validators or REGISTRATION_VALIDATORS
+
     add_error = add_error or raise_validation_error
     for validator in validators:
+        validator(request, cleaned_data, add_error)
+    for validator in hooks.new_registrations_validators:
         validator(request, cleaned_data, add_error)


### PR DESCRIPTION
This PR is a follow up for #1309 and adds following hooks for plugins:

- `new_registrations_validators`
- `post_search_filters`
- `post_validators`