### PR TITLE
Add hooks to parser

### DIFF
--- a/misago/hooks.py
+++ b/misago/hooks.py
@@ -5,3 +5,6 @@ context_processors = []
 new_registrations_validators = []
 post_search_filters = []
 post_validators = []
+
+markdown_extensions = []
+parsing_result_processors = []

--- a/misago/markup/pipeline.py
+++ b/misago/markup/pipeline.py
@@ -2,6 +2,7 @@ from importlib import import_module
 
 from bs4 import BeautifulSoup
 
+from .. import hooks
 from ..conf import settings
 
 
@@ -14,6 +15,10 @@ class MarkupPipeline:
             if hasattr(module, "extend_markdown"):
                 hook = getattr(module, "extend_markdown")
                 hook.extend_markdown(md)
+
+        for extension in hooks.markdown_extensions:
+            extension(md)
+
         return md
 
     def process_result(self, result):
@@ -23,6 +28,9 @@ class MarkupPipeline:
             if hasattr(module, "clean_parsed"):
                 hook = getattr(module, "clean_parsed")
                 hook.process_result(result, soup)
+
+        for extension in hooks.parsing_result_processors:
+            extension(result, soup)
 
         souped_text = str(soup.body).strip()[6:-7]
         result["parsed_text"] = souped_text.strip()

--- a/misago/markup/tests/test_pipeline_hooks.py
+++ b/misago/markup/tests/test_pipeline_hooks.py
@@ -1,0 +1,17 @@
+from unittest.mock import ANY
+
+from ..pipeline import pipeline
+
+
+def test_markdown_extensions_hook_is_called_by_pipeline(mocker):
+    plugin = mocker.Mock()
+    mocker.patch("misago.markup.pipeline.hooks.markdown_extensions", [plugin])
+    pipeline.extend_markdown(mocker.Mock())
+    plugin.asssert_called_once_with(ANY)
+
+
+def test_parsing_result_processors_hook_is_called_by_pipeline(mocker):
+    plugin = mocker.Mock()
+    mocker.patch("misago.markup.pipeline.hooks.parsing_result_processors", [plugin])
+    pipeline.extend_markdown(mocker.Mock())
+    plugin.asssert_called_once_with(ANY, ANY)


### PR DESCRIPTION
This PR updates `misago.markup.pipeline` to support two hooks:

- `markdown_extensions`
- `parsing_result_processors`