### PR TITLE
Update Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ADD requirements-plugins.txt /
 
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    pip install -r requirements-plugins.txt &&
+    pip install -r requirements-plugins.txt
 
 WORKDIR /srv/misago
 


### PR DESCRIPTION
The line 28 contained the string "    pip install -r requirements-plugins.txt &&" which caused the error ```/bin/sh: 1: Syntax error: end of file unexpected
Service 'misago' failed to build: The command '/bin/sh -c pip install --upgrade pip &&     pip install -r requirements.txt &&     pip install -r requirements-plugins.txt &&' returned a non-zero code: 2```
Therefore, I removed the characters "&&" and solved. 
Finally, following my suggestion of modification on this Dockerfile. Thank you, Igor