### PR TITLE
Change length of the query word to > 1

### DIFF
--- a/misago/threads/search.py
+++ b/misago/threads/search.py
@@ -21,7 +21,7 @@ class SearchThreads(SearchProvider):
         root_category = ThreadsRootCategory(self.request)
         threads_categories = [root_category.unwrap()] + root_category.subcategories
 
-        if len(query) > 2:
+        if len(query) > 1:
             visible_threads = exclude_invisible_threads(
                 self.request.user_acl, threads_categories, Thread.objects
             )


### PR DESCRIPTION
The previous version:  
  Search function can not work very well in Chinese, for example, there are lots of Chinese words which length is 2, such as apple/duck/eyes/nose and etc., these words in Chinese are 苹果/鸭子/眼睛/鼻子, so the length of the query limitation should be > 1 , not > 2.

The update version:
  Search function can work very well in Chinese word searching. ;-D