### PR TITLE
Fix #1345: User default subscriptions not saving on user creation

### DIFF
--- a/misago/users/setupnewuser.py
+++ b/misago/users/setupnewuser.py
@@ -27,3 +27,7 @@ def set_default_subscription_options(settings, user):
 
     replied_threads = SUBSCRIPTION_CHOICES[settings.subscribe_reply]
     user.subscribe_to_replied_threads = replied_threads
+
+    user.save(
+        update_fields=["subscribe_to_replied_threads", "subscribe_to_replied_threads"]
+    )


### PR DESCRIPTION
Issue #1345 

* Change in default subscription option from the admin section doesn't bind to a newly created user.