### PR TITLE
Two popups even cancel the first popup while add an image in editor.

### DIFF
--- a/frontend/src/components/editor/actions/image.js
+++ b/frontend/src/components/editor/actions/image.js
@@ -23,9 +23,9 @@ export function insertImage(selection, replace) {
   }
 
   url = $.trim(prompt(gettext("Enter link to image") + ":", url))
-  label = $.trim(prompt(gettext("Enter image label (optional)") + ":", label))
 
   if (url.length) {
+    label = $.trim(prompt(gettext("Enter image label (optional)") + ":", label))
     if (label.length > 0) {
       replace("![" + label + "](" + url + ")")
     } else {


### PR DESCRIPTION
While insert an image, there is a popup which asks for a url of the image. If cancel, it still asks for image label as another popup. I think we don't need the second popup, if first popup cancel or empty.
