### PR TITLE
Swap daily/hourly cutoff timedelta for floodprotection middleware

### DIFF
--- a/misago/threads/api/postingendpoint/floodprotection.py
+++ b/misago/threads/api/postingendpoint/floodprotection.py
@@ -29,14 +29,14 @@ class FloodProtectionMiddleware(PostingMiddleware):
         self.user.update_fields.append("last_posted_on")
 
         if self.settings.hourly_post_limit:
-            cutoff = now - timedelta(hours=24)
+            cutoff = now - timedelta(hours=1)
             if self.is_limit_exceeded(cutoff, self.settings.hourly_post_limit):
                 raise PostingInterrupt(
                     _("Your account has exceed an hourly post limit.")
                 )
 
         if self.settings.daily_post_limit:
-            cutoff = now - timedelta(hours=1)
+            cutoff = now - timedelta(hours=24)
             if self.is_limit_exceeded(cutoff, self.settings.daily_post_limit):
                 raise PostingInterrupt(_("Your account has exceed a daily post limit."))
 


### PR DESCRIPTION
Swaps the timedelta for the hourly and daily cutoff for the flood protection middleware.

Hourly was using `timedelta(hours=24)` and daily was using `timedelta(hours=1)`. 