### PR TITLE
Add Python 3.11 to test runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,11 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+
     services:
         postgres:
           image: postgres:11
@@ -14,17 +19,18 @@ jobs:
             POSTGRES_DB: misago
           ports:
             - 5432:5432
+
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-      - name: Test with pytest
+      - name: Pytest
         env:
           DJANGO_SETTINGS_MODULE: devproject.test_settings
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
Adds Python 3.11 to test runner to see if Misago works with that version, and if it does, then how much faster it is.