### PR TITLE
Set locale for tests

### DIFF
--- a/devproject/test_settings.py
+++ b/devproject/test_settings.py
@@ -32,7 +32,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Use english search config
 MISAGO_SEARCH_CONFIG = "english"
 
-# Test assertions expect an english responses
+# Test assertions expect english locale
 LANGUAGE_CODE = "en-us"
 
 # Register test post validator

--- a/devproject/test_settings.py
+++ b/devproject/test_settings.py
@@ -32,6 +32,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Use english search config
 MISAGO_SEARCH_CONFIG = "english"
 
+# Test assertions expect an english responses
+LANGUAGE_CODE = "en-us"
+
 # Register test post validator
 MISAGO_POST_VALIDATORS = ["misago.core.testproject.validators.test_post_validator"]
 


### PR DESCRIPTION
#1426 Set locale in test_settings.py

Now tests shouldn't fail if the main settings file is set non English locale