### PR TITLE
Fix normalizing/filtering user data

### DIFF
--- a/misago/oauth2/tests/test_get_user_data.py
+++ b/misago/oauth2/tests/test_get_user_data.py
@@ -382,6 +382,57 @@ def test_user_data_json_values_are_mapped_to_result(mock_request):
     oauth2_json_id_path="id",
     oauth2_json_name_path="user.profile.name",
     oauth2_json_email_path="user.profile.email",
+    oauth2_json_avatar_path="user.profile.avatar",
+)
+def test_user_data_json_values_are_none_when_not_found(mock_request):
+    user_data = {
+        "id": "7dds8a7dd89sa",
+        "name": "Aerith",
+        "email": "aerith@example.com",
+        "avatar": "https://example.com/avatar.png",
+    }
+
+    get_mock = Mock(
+        return_value=Mock(
+            status_code=200,
+            json=Mock(
+                return_value={
+                    "profile_id": user_data["id"],
+                    "user": {
+                        "data": {
+                            "name": user_data["name"],
+                            "email": user_data["email"],
+                            "avatar": user_data["avatar"],
+                        }
+                    },
+                },
+            ),
+        ),
+    )
+
+    with patch("requests.get", get_mock):
+        assert get_user_data(mock_request, ACCESS_TOKEN) == {
+            "id": None,
+            "name": None,
+            "email": None,
+            "avatar": None,
+        }
+
+        get_mock.assert_called_once_with(
+            f"https://example.com/oauth2/data?type=user&atoken={ACCESS_TOKEN}",
+            headers={},
+            timeout=REQUESTS_TIMEOUT,
+        )
+
+
+@override_dynamic_settings(
+    oauth2_user_url="https://example.com/oauth2/data?type=user",
+    oauth2_user_method="GET",
+    oauth2_user_token_name="atoken",
+    oauth2_user_token_location="QUERY",
+    oauth2_json_id_path="id",
+    oauth2_json_name_path="user.profile.name",
+    oauth2_json_email_path="user.profile.email",
     oauth2_json_avatar_path="",
 )
 def test_user_data_skips_avatar_if_path_is_not_set(mock_request):

--- a/misago/oauth2/tests/test_getting_json_values.py
+++ b/misago/oauth2/tests/test_getting_json_values.py
@@ -29,3 +29,21 @@ def test_json_value_is_returned_from_nested_objects():
         )
         == "ok"
     )
+
+
+def test_none_is_returned_from_nested_objects():
+    assert (
+        get_value_from_json(
+            "val.child.val3",
+            {
+                "val2": "nope",
+                "val": {
+                    "child": {
+                        "val2": "nope",
+                        "val": "ok",
+                    },
+                },
+            },
+        )
+        is None
+    )

--- a/misago/oauth2/tests/test_user_data_filter.py
+++ b/misago/oauth2/tests/test_user_data_filter.py
@@ -43,6 +43,136 @@ def test_existing_user_data_is_filtered_using_default_filters(user, request):
     }
 
 
+def test_empty_user_name_is_replaced_with_placeholder_one(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": None,
+            "email": "oauth2@example.com",
+            "avatar": None,
+        },
+    )
+
+    assert len(filtered_data["name"].strip())
+
+
+def test_missing_user_name_is_replaced_with_placeholder_one(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": None,
+            "email": "oauth2@example.com",
+            "avatar": None,
+        },
+    )
+
+    assert len(filtered_data["name"].strip())
+
+
+def test_user_name_is_converted_to_str(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": 123456,
+            "email": "oauth2@example.com",
+            "avatar": None,
+        },
+    )
+
+    assert filtered_data == {
+        "id": "242132",
+        "name": "123456",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+
+def test_user_email_is_converted_to_str(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": "New User",
+            "email": [1, 2, 4, "d"],
+            "avatar": None,
+        },
+    )
+
+    assert filtered_data == {
+        "id": "242132",
+        "name": "New_User",
+        "email": "[1, 2, 4, 'd']",
+        "avatar": None,
+    }
+
+
+def test_missing_user_email_is_set_as_empty_str(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": "New User",
+            "email": None,
+            "avatar": None,
+        },
+    )
+
+    assert filtered_data == {
+        "id": "242132",
+        "name": "New_User",
+        "email": "",
+        "avatar": None,
+    }
+
+
+def test_user_avatar_is_converted_to_str(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": "New User",
+            "email": "oauth2@example.com",
+            "avatar": 123456,
+        },
+    )
+
+    assert filtered_data == {
+        "id": "242132",
+        "name": "New_User",
+        "email": "oauth2@example.com",
+        "avatar": "123456",
+    }
+
+
+def test_empty_user_avatar_is_filtered_to_none(db, request):
+    filtered_data = filter_user_data(
+        request,
+        None,
+        {
+            "id": "242132",
+            "name": "New User",
+            "email": "oauth2@example.com",
+            "avatar": "",
+        },
+    )
+
+    assert filtered_data == {
+        "id": "242132",
+        "name": "New_User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+
 def user_request_filter(request, user, user_data):
     assert request
 
@@ -144,3 +274,71 @@ def test_existing_user_data_is_filtered_using_custom_filters(user, request):
             "email": "filtered_oauth2@example.com",
             "avatar": None,
         }
+
+
+def test_original_user_data_is_not_mutated_by_default_filters(user, request):
+    user_data = {
+        "id": "1234",
+        "name": "New User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+    filtered_data = filter_user_data(request, user, user_data)
+    assert filtered_data == {
+        "id": "1234",
+        "name": "New_User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+    assert user_data == {
+        "id": "1234",
+        "name": "New User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+
+def test_original_user_data_is_not_mutated_by_custom_filters(user, request):
+    def user_is_set_filter(request, user_obj, user_data):
+        assert user_obj == user
+        return {
+            "id": str(user_obj.id),
+            "name": user_data["name"],
+            "email": user_data["email"],
+            "avatar": user_data["avatar"],
+        }
+
+    user_data = {
+        "id": "1234",
+        "name": "New User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }
+
+    with patch(
+        "misago.oauth2.validation.oauth2_user_data_filters",
+        [
+            user_request_filter,
+            user_is_set_filter,
+            user_id_filter,
+            user_name_filter,
+            user_email_filter,
+        ],
+    ):
+        filtered_data = filter_user_data(request, user, user_data)
+
+        assert filtered_data == {
+            "id": "".join(reversed(str(user.id))),
+            "name": "resU weN",
+            "email": "filtered_oauth2@example.com",
+            "avatar": None,
+        }
+
+    assert user_data == {
+        "id": "1234",
+        "name": "New User",
+        "email": "oauth2@example.com",
+        "avatar": None,
+    }

--- a/misago/oauth2/user.py
+++ b/misago/oauth2/user.py
@@ -15,6 +15,7 @@ def get_user_from_data(request, user_data):
     if not user_data["id"]:
         raise OAuth2UserIdNotProvidedError()
 
+    user_data["id"] = str(user_data["id"])
     user = get_user_by_subject(user_data["id"])
     if not user and user_data["email"]:
         user = get_user_by_email(user_data["id"], user_data["email"])

--- a/misago/oauth2/validation.py
+++ b/misago/oauth2/validation.py
@@ -53,7 +53,7 @@ def filter_user_data(request, user, user_data):
         "id": user_data["id"],
         "name": str(user_data["name"] or "").strip(),
         "email": str(user_data["email"] or "").strip(),
-        "avatar": str(user_data["avatar"]).strip() if user_data["avatar"] else None,
+        "avatar": filter_user_avatar(user_data["avatar"]),
     }
 
     if oauth2_user_data_filters:
@@ -64,6 +64,12 @@ def filter_user_data(request, user, user_data):
         filtered_data["name"] = filter_name(user, filtered_data["name"])
 
     return filtered_data
+
+
+def filter_user_avatar(user_avatar):
+    if user_avatar:
+        return str(user_avatar).strip() or None
+    return None
 
 
 def filter_user_data_with_filters(request, user, user_data, filters):

--- a/misago/oauth2/validation.py
+++ b/misago/oauth2/validation.py
@@ -68,7 +68,7 @@ def filter_user_data(request, user, user_data):
 
 def filter_user_data_with_filters(request, user, user_data, filters):
     for filter_user_data in filters:
-        user_data = filter_user_data(request, user, user_data) or user_data
+        user_data = filter_user_data(request, user, user_data.copy()) or user_data
     return user_data
 
 


### PR DESCRIPTION
Fixes #1440

- don't mutate user data when filtering
- always convert name to str
- convert empty name to empty str
- always convert email to str
- convert empty email to empty str
- aways convert avatar to str if its not empty