### PR TITLE
Remove Python 3.10 from tests matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
 
     services:
         postgres:


### PR DESCRIPTION
Docker containers are already running on Python 3.11