### PR TITLE
Set CSS class on body element depending on auth state

### DIFF
--- a/misago/core/tests/test_body_css_class.py
+++ b/misago/core/tests/test_body_css_class.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+
+from ...test import assert_contains, assert_not_contains
+
+
+def test_body_has_misago_anonymous_css_class_if_user_is_anonymous(db, client):
+    response = client.get(reverse("misago:index"))
+    assert_contains(response, 'class="misago-anonymous')
+    assert_not_contains(response, 'class="misago-authenticated')
+
+
+def test_body_has_misago_authenticated_css_class_if_user_is_authenticated(user_client):
+    response = user_client.get(reverse("misago:index"))
+    assert_contains(response, 'class="misago-authenticated')
+    assert_not_contains(response, 'class="misago-anonymous')

--- a/misago/templates/misago/base.html
+++ b/misago/templates/misago/base.html
@@ -63,7 +63,7 @@
     {% endspaceless %}
     <script type="application/ld+json">{"@context":"http://schema.org","@type":"WebSite","url":"{{ settings.forum_address }}"}</script>
   </head>
-  <body {% if misago_agreement %}class="agreement-overlay-visible"{% endif %}>
+  <body class="misago-{% if user.is_authenticated %}authenticated{% else %}anonymous{% endif %}{% if misago_agreement %} agreement-overlay-visible{% endif %}">
     {% if settings.google_tracking_id %}
       {% include "misago/analytics.html" %}
     {% endif %}


### PR DESCRIPTION
Sets `misago-authenticated` CSS class on `body` element if user is authenticated, and `misago-anonymous` otherwise. Not used by Misago itself, but useful for site customization. 

Fixes #1468