### PR TITLE
Update cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ coverage[toml]==6.5.0
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements.in
-cryptography==37.0.4
+cryptography==40.0.2
     # via social-auth-core
 defusedxml==0.7.1
     # via


### PR DESCRIPTION
- Use the latest cryptography pip modul, beacuse of this error:
![grafik](https://github.com/rafalp/Misago/assets/49990629/8d0c3032-24fa-4685-bbbc-c4f62b670085)