### PR TITLE
Add versioning to server and browser cache for django-i18n.js, cache it for 180 days

### DIFF
--- a/devproject/urls.py
+++ b/devproject/urls.py
@@ -27,10 +27,14 @@ from misago.users.forms.auth import AdminAuthenticationForm
 
 
 # Cache key for django-i18n.js view that invalidates cache when
-# Misago version, release status or language code changes 
+# Misago version, release status or language code changes
 misago_i18n_cache_key = (
-    f"misagojsi18n_{settings.LANGUAGE_CODE}_{__version__}_{__released__}"
-).replace(".", "_").replace("-", "_").lower()
+    (f"misagojsi18n_{settings.LANGUAGE_CODE}_{__version__}_{__released__}")
+    .replace(".", "_")
+    .replace("-", "_")
+    .lower()
+)
+
 
 admin.autodiscover()
 admin.site.login_form = AdminAuthenticationForm

--- a/devproject/urls.py
+++ b/devproject/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     path(
         "django-i18n.js",
         last_modified(lambda req, **kw: timezone.now())(
-            cache_page(86400 * 180, key_prefix=misago_i18n_cache_key)(
+            cache_page(86400 * 21, key_prefix=misago_i18n_cache_key)(
                 JavaScriptCatalog.as_view(packages=["misago"])
             )
         ),

--- a/devproject/urls.py
+++ b/devproject/urls.py
@@ -22,8 +22,15 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.http import last_modified
 from django.views.i18n import JavaScriptCatalog
 
+from misago import __released__, __version__
 from misago.users.forms.auth import AdminAuthenticationForm
 
+
+# Cache key for django-i18n.js view that invalidates cache when
+# Misago version, release status or language code changes 
+misago_i18n_cache_key = (
+    f"misagojsi18n_{settings.LANGUAGE_CODE}_{__version__}_{__released__}"
+).replace(".", "_").replace("-", "_").lower()
 
 admin.autodiscover()
 admin.site.login_form = AdminAuthenticationForm
@@ -35,7 +42,7 @@ urlpatterns = [
     path(
         "django-i18n.js",
         last_modified(lambda req, **kw: timezone.now())(
-            cache_page(86400 * 2, key_prefix="misagojsi18n")(
+            cache_page(86400 * 180, key_prefix=misago_i18n_cache_key)(
                 JavaScriptCatalog.as_view(packages=["misago"])
             )
         ),

--- a/misago/__init__.py
+++ b/misago/__init__.py
@@ -1,5 +1,5 @@
 from .plugins.pluginlist import load_plugin_list_if_exists
 
 
-__version__ = "0.37.0"
-__released__ = True
+__version__ = "0.37.1"
+__released__ = False

--- a/misago/conf/context_processors.py
+++ b/misago/conf/context_processors.py
@@ -1,10 +1,22 @@
 import json
+from hashlib import sha256
 
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.translation import get_language
 
+import misago
 from . import settings
+
+
+# Simple but hard to guess version signature for current Misago version
+# Used to cache-bust django-i18n.js URL in the browser
+I18N_VERSION_HASH = sha256(
+    (
+        f"{misago.__version__}{misago.__released__}"
+        f"{settings.LANGUAGE_CODE}{settings.SECRET_KEY}"
+    ).encode("utf-8")
+).hexdigest()
 
 
 def conf(request):
@@ -13,6 +25,7 @@ def conf(request):
             request.settings.blank_avatar or static(settings.MISAGO_BLANK_AVATAR)
         ),
         "DEBUG": settings.DEBUG,
+        "I18N_VERSION_HASH": I18N_VERSION_HASH,
         "LANGUAGE_CODE_SHORT": get_language()[:2],
         "LOGIN_REDIRECT_URL": settings.LOGIN_REDIRECT_URL,
         "LOGIN_URL": settings.LOGIN_URL,

--- a/misago/conf/context_processors.py
+++ b/misago/conf/context_processors.py
@@ -11,7 +11,7 @@ from . import settings
 
 # Simple but hard to guess version signature for current Misago version
 # Used to cache-bust django-i18n.js URL in the browser
-I18N_VERSION_HASH = sha256(
+I18N_VERSION_SIGNATURE = sha256(
     (
         f"{misago.__version__}{misago.__released__}"
         f"{settings.LANGUAGE_CODE}{settings.SECRET_KEY}"
@@ -25,7 +25,7 @@ def conf(request):
             request.settings.blank_avatar or static(settings.MISAGO_BLANK_AVATAR)
         ),
         "DEBUG": settings.DEBUG,
-        "I18N_VERSION_HASH": I18N_VERSION_HASH,
+        "I18N_VERSION_SIGNATURE": I18N_VERSION_SIGNATURE,
         "LANGUAGE_CODE_SHORT": get_language()[:2],
         "LOGIN_REDIRECT_URL": settings.LOGIN_REDIRECT_URL,
         "LOGIN_URL": settings.LOGIN_URL,

--- a/misago/core/tests/test_jsi18n.py
+++ b/misago/core/tests/test_jsi18n.py
@@ -14,7 +14,7 @@ LOCALES_DIR = os.path.join(MISAGO_DIR, "locale")
 class JsI18nUrlTests(TestCase):
     def test_url_cache_buster(self):
         """js i18n catalog link has cachebuster with lang code"""
-        url = "%s?%s" % (reverse("django-i18n"), settings.LANGUAGE_CODE)
+        url = "%s?l=%s" % (reverse("django-i18n"), settings.LANGUAGE_CODE)
 
         response = self.client.get(reverse("misago:index"))
         self.assertContains(response, url)

--- a/misago/templates/misago/base.html
+++ b/misago/templates/misago/base.html
@@ -102,7 +102,7 @@
       {% include "misago/required_agreement.html" %}
     {% endif %}
 
-    <script src="{% url 'django-i18n' %}?l={{ LANGUAGE_CODE }}&v={{ I18N_VERSION_HASH }}"></script>
+    <script src="{% url 'django-i18n' %}?l={{ LANGUAGE_CODE }}&v={{ I18N_VERSION_SIGNATURE }}"></script>
     <script src="{% static 'misago/js/vendor.js' %}"></script>
     <script src="{% static 'misago/js/misago.js' %}"></script>
     {% include "misago/scripts.html" %}

--- a/misago/templates/misago/base.html
+++ b/misago/templates/misago/base.html
@@ -102,7 +102,7 @@
       {% include "misago/required_agreement.html" %}
     {% endif %}
 
-    <script src="{% url 'django-i18n' %}?{{ LANGUAGE_CODE }}"></script>
+    <script src="{% url 'django-i18n' %}?l={{ LANGUAGE_CODE }}&v={{ I18N_VERSION_HASH }}"></script>
     <script src="{% static 'misago/js/vendor.js' %}"></script>
     <script src="{% static 'misago/js/misago.js' %}"></script>
     {% include "misago/scripts.html" %}


### PR DESCRIPTION
Updates `django-i18n.js` cache on the server to include Misago's version, release status and current language code in cache key.

Also adds `I18N_VERSION_SIGNATURE` to template context that is a SHA256 hash of the above + secret key, so this hash can't be used to guess what version of Misago the site is running. But still changes when site's Misago installation is changed.

This hash is used in link to `django-i18n.js` view and will trigger browser to pull new version of file when site is updated.

Fixes #1658