### PR TITLE
Check if exception's message is str before deciding to use it instead of default

### DIFF
--- a/misago/core/errorpages.py
+++ b/misago/core/errorpages.py
@@ -20,7 +20,8 @@ def _is_ajax(request):
 
 def _ajax_error(code, exception=None, default_message=None):
     return JsonResponse(
-        {"detail": get_exception_message(exception, default_message)}, status=code
+        {"detail": get_exception_message(exception, default_message)},
+        status=code,
     )
 
 

--- a/misago/core/tests/test_utils.py
+++ b/misago/core/tests/test_utils.py
@@ -2,6 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import Resolver404, reverse
+from django.utils.functional import lazystr
 
 from ..utils import (
     clean_ids_list,
@@ -271,6 +272,9 @@ class GetExceptionMessageTests(TestCase):
         """helper's default message arg is optional"""
         message = get_exception_message(PermissionDenied("Lorem Ipsum"))
         self.assertEqual(message, "Lorem Ipsum")
+
+        message = get_exception_message(PermissionDenied(lazystr("Lazy Error")))
+        self.assertEqual(message, "Lazy Error")
 
         message = get_exception_message(PermissionDenied())
         self.assertIsNone(message)

--- a/misago/core/tests/test_utils.py
+++ b/misago/core/tests/test_utils.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.urls import reverse
+from django.urls import Resolver404, reverse
 
 from ..utils import (
     clean_ids_list,
@@ -281,6 +281,9 @@ class GetExceptionMessageTests(TestCase):
         self.assertEqual(message, "Lorem Ipsum")
 
         message = get_exception_message(PermissionDenied(), "Default")
+        self.assertEqual(message, "Default")
+
+        message = get_exception_message(Resolver404({"path": "/invalid/"}), "Default")
         self.assertEqual(message, "Default")
 
         message = get_exception_message(default_message="Lorem Ipsum")

--- a/misago/core/tests/test_utils.py
+++ b/misago/core/tests/test_utils.py
@@ -2,7 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import Resolver404, reverse
-from django.utils.functional import lazystr
+from django.utils.functional import lazy, lazystr
 
 from ..utils import (
     clean_ids_list,

--- a/misago/core/utils.py
+++ b/misago/core/utils.py
@@ -146,7 +146,7 @@ def get_exception_message(exception=None, default_message=None):
     try:
         exception_message = exception.args[0]
         if isinstance(exception_message, Promise):
-            exception_message = str(exception_message)
+            return str(exception_message)
         if isinstance(exception_message, str):
             return exception_message
         return default_message

--- a/misago/core/utils.py
+++ b/misago/core/utils.py
@@ -143,7 +143,10 @@ def get_exception_message(exception=None, default_message=None):
         return default_message
 
     try:
-        return exception.args[0]
+        exception_message = exception.args[0]
+        if isinstance(exception_message, str):
+            return exception_message
+        return default_message
     except IndexError:
         return default_message
 

--- a/misago/core/utils.py
+++ b/misago/core/utils.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from django.urls import resolve, reverse
 from django.utils import html, timezone
 from django.utils.encoding import force_str
+from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 
 MISAGO_SLUGIFY = getattr(settings, "MISAGO_SLUGIFY", "misago.core.slugify.default")
@@ -144,6 +145,8 @@ def get_exception_message(exception=None, default_message=None):
 
     try:
         exception_message = exception.args[0]
+        if isinstance(exception_message, Promise):
+            exception_message = str(exception_message)
         if isinstance(exception_message, str):
             return exception_message
         return default_message


### PR DESCRIPTION
Fixes #1665 