### PR TITLE
Install plugins from pip-install.txt file if it exists

### DIFF
--- a/dev
+++ b/dev
@@ -205,6 +205,12 @@ bootstrap_plugins() {
                 echo "Skipping plugin bootstrap for: $plugin_name"
             fi
         done
+
+        pip_install="$MISAGO_PLUGINS/pip-install.txt"
+        if [ -f $pip_install ]; then
+            echo "Installing: $pip_install"
+            pip install -r $pip_install
+        fi
     else
         echo "Skipping plugin bootstrap because plugins directory doesn't exist."
     fi

--- a/misago/plugins/discover.py
+++ b/misago/plugins/discover.py
@@ -53,17 +53,17 @@ def discover_plugins_in_directory(plugins_path: Path) -> List[str]:
 
 
 def discover_plugins_in_pip_install(pip_install_path: Path) -> List[str]:
-    pip_install_lines = read_lines_from_pip_install(pip_install_path)
+    pip_install_lines = read_pip_install_file(pip_install_path)
     return validate_modules_from_pip_install(pip_install_lines)
 
 
 PIP_LINE_RE = re.compile("^[a-z0-9-_]+")
 
 
-def read_lines_from_pip_install(pip_install_path: Path) -> List[str]:
+def read_pip_install_file(pip_install_path: Path) -> List[str]:
     clean_lines: List[str] = []
     with open(pip_install_path, "r") as fp:
-        file_lines: List[str] = fp.read().splitlines()
+        file_lines: List[str] = fp.readlines()
         for file_line in file_lines:
             clean_line = file_line.strip()
             if clean_line.startswith("#"):

--- a/misago/plugins/templatetags/misago_plugins.py
+++ b/misago/plugins/templatetags/misago_plugins.py
@@ -38,7 +38,6 @@ class PluginOutletNode(template.Node):
         outlet_html = ""
         for plugin_html in outlet(context):
             if plugin_html is not None:
-                print(plugin_html)
                 outlet_html += conditional_escape(plugin_html)
         return mark_safe(outlet_html)
 

--- a/misago/plugins/tests/test_discover_plugins.py
+++ b/misago/plugins/tests/test_discover_plugins.py
@@ -142,3 +142,49 @@ def test_discover_plugins_skips_plugins_without_init(sys_mock):
         plugins = discover_plugins(plugins_dir)
         assert plugins == ["mock_plugin"]
         assert sys_mock.path == [f"{plugins_dir}/mock-plugin"]
+
+
+def create_pip_install(plugins_dir: str, contents: list[str]):
+    with open(Path(plugins_dir) / "pip-install.txt", "w") as fp:
+        fp.write("\n".join(contents))
+
+
+@pytest.mark.xfail(reason="requires misago-pypi-plugin installed to pass")
+def test_discover_plugins_reads_plugins_from_pip_install_if_it_exists(sys_mock):
+    with TemporaryDirectory() as plugins_dir:
+        create_pip_install(plugins_dir, ["misago-pypi-plugin"])
+
+        plugins = discover_plugins(plugins_dir)
+        assert plugins == ["misago_pypi_plugin"]
+        assert sys_mock.path == []
+
+
+@pytest.mark.xfail(reason="requires misago-pypi-plugin installed to pass")
+def test_discover_plugins_skips_pip_install_entries_that_arent_installed(sys_mock):
+    with TemporaryDirectory() as plugins_dir:
+        create_pip_install(plugins_dir, ["misago-pypi-plugin", "misago-other-plugin"])
+
+        plugins = discover_plugins(plugins_dir)
+        assert plugins == ["misago_pypi_plugin"]
+        assert sys_mock.path == []
+
+
+@pytest.mark.xfail(reason="requires misago-pypi-plugin installed to pass")
+def test_discover_plugins_skips_pip_install_entries_that_arent_misago_plugins(sys_mock):
+    with TemporaryDirectory() as plugins_dir:
+        create_pip_install(plugins_dir, ["misago-pypi-plugin", "django"])
+
+        plugins = discover_plugins(plugins_dir)
+        assert plugins == ["misago_pypi_plugin"]
+        assert sys_mock.path == []
+
+
+@pytest.mark.xfail(reason="requires misago-pypi-plugin installed to pass")
+def test_discover_plugins_skips_pip_install_if_its_directory(sys_mock):
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        pip_install_path.mkdir()
+
+        plugins = discover_plugins(plugins_dir)
+        assert plugins == []
+        assert sys_mock.path == []

--- a/misago/plugins/tests/test_read_pip_install_file.py
+++ b/misago/plugins/tests/test_read_pip_install_file.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ..discover import read_pip_install_file
+
+
+def test_empty_pip_install_file_is_read_to_empty_list():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w"):
+            pass
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == []
+
+
+def test_pip_install_file_is_read_without_comments_lines():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.writelines(["# comment\n", "other\n"])
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["other"]
+
+
+def test_pip_install_file_is_read_without_comments_after_content():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.write("line # comment")
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["line"]
+
+
+def test_pip_install_file_is_read_lines_trimmed():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.writelines(["line   \n", "    other\n"])
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["line", "other"]
+
+
+def test_pip_install_file_is_read_without_duplicate_lines():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.writelines(["line\n", "other\n", "line\n"])
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["line", "other"]
+
+
+def test_pip_install_file_is_read_without_version_data():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.write("line==0.12rc1\n")
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["line"]
+
+
+def test_pip_install_file_is_read_with_names_converted_to_package_names():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.write("plugin-name\n")
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["plugin_name"]
+
+
+def test_pip_install_file_is_read_with_blank_lines_skipped():
+    with TemporaryDirectory() as plugins_dir:
+        pip_install_path = Path(plugins_dir) / "pip-install.txt"
+        with open(pip_install_path, "w") as fp:
+            fp.write("plugin-name\n\nline")
+
+        file_contents = read_pip_install_file(pip_install_path)
+        assert file_contents == ["plugin_name", "line"]

--- a/misago/templates/misago/admin/plugins/list.html
+++ b/misago/templates/misago/admin/plugins/list.html
@@ -88,7 +88,7 @@
           {% if item.has_urls %}
             <div class="dropdown">
               <button class="btn btn-light btn-sm dropdown-toggle" type="button" id="plugin-links-{{ item.package }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="{% trans 'See plugin links' context 'admin plugins links' %}">
-                <span class="fa fa-link"></span>
+                <span class="fa fa-external-link-alt"></span>
               </button>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="plugin-links-{{ item.package }}">
                 {% if item.homepage %}

--- a/plugins/pip-install.txt
+++ b/plugins/pip-install.txt
@@ -1,0 +1,2 @@
+# Install Misago PyPI plugin
+misago-pypi-plugin==0.2


### PR DESCRIPTION
Adds support for plugins installation with `pip` from `plugins/pip-install.txt` file

TODO:

- [x] Install plugins from `pip-install.txt`
- [x] Include `pip-install.txt` plugins in `INSTALLED_PLUGINS`
- [x] Display `pip-install.txt` plugins on admin plugin list

Part of #1524 epic