### PR TITLE
Replace old OAuth 2 hooks with new ones

### DIFF
--- a/misago/hooks.py
+++ b/misago/hooks.py
@@ -4,9 +4,6 @@ context_processors = []
 
 new_registrations_validators = []
 
-oauth2_user_data_filters = []
-oauth2_validators = []
-
 post_search_filters = []
 post_validators = []
 

--- a/misago/oauth2/hooks/__init__.py
+++ b/misago/oauth2/hooks/__init__.py
@@ -1,0 +1,2 @@
+from .filter_user_data import filter_user_data_hook
+from .validate_user_data import validate_user_data_hook

--- a/misago/oauth2/hooks/filter_user_data.py
+++ b/misago/oauth2/hooks/filter_user_data.py
@@ -1,0 +1,47 @@
+from typing import Optional, Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ...users.models import User
+
+
+class FilterUserDataHookAction(Protocol):
+    def __call__(
+        self,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+    ) -> dict:
+        pass
+
+
+class FilterUserDataHookFilter(Protocol):
+    def __call__(
+        self,
+        action: FilterUserDataHookAction,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+    ) -> dict:
+        pass
+
+
+class FilterUserDataHook(
+    FilterHook[FilterUserDataHookAction, FilterUserDataHookFilter]
+):
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: FilterUserDataHookAction,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+        *args,
+        **kwargs,
+    ) -> dict:
+        return super().__call__(action, request, user, user_data, *args, **kwargs)
+
+
+filter_user_data_hook = FilterUserDataHook()

--- a/misago/oauth2/hooks/validate_user_data.py
+++ b/misago/oauth2/hooks/validate_user_data.py
@@ -1,0 +1,52 @@
+from typing import Optional, Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ...users.models import User
+
+
+class ValidateUserDataHookAction(Protocol):
+    def __call__(
+        self,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+        response_json: dict,
+    ) -> dict:
+        pass
+
+
+class ValidateUserDataHookFilter(Protocol):
+    def __call__(
+        self,
+        action: ValidateUserDataHookAction,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+        response_json: dict,
+    ) -> dict:
+        pass
+
+
+class ValidateUserDataHook(
+    FilterHook[ValidateUserDataHookAction, ValidateUserDataHookFilter]
+):
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: ValidateUserDataHookAction,
+        request: HttpRequest,
+        user: Optional[User],
+        user_data: dict,
+        response_json: dict,
+        *args,
+        **kwargs,
+    ) -> dict:
+        return super().__call__(
+            action, request, user, user_data, response_json, *args, **kwargs
+        )
+
+
+validate_user_data_hook = ValidateUserDataHook()

--- a/misago/oauth2/tests/conftest.py
+++ b/misago/oauth2/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def disable_user_data_filters():
+    pass

--- a/misago/oauth2/tests/conftest.py
+++ b/misago/oauth2/tests/conftest.py
@@ -1,6 +1,13 @@
+from unittest.mock import patch
+
 import pytest
+
+
+def noop_filter_user_data(request, user, user_data):
+    return user_data
 
 
 @pytest.fixture
 def disable_user_data_filters():
-    pass
+    with patch("misago.oauth2.validation.filter_user_data", noop_filter_user_data):
+        yield

--- a/misago/oauth2/tests/test_user_creation_from_data.py
+++ b/misago/oauth2/tests/test_user_creation_from_data.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -92,29 +92,20 @@ def test_user_is_created_with_admin_activation_from_valid_data(db, dynamic_setti
     assert user.requires_activation == User.ACTIVATION_ADMIN
 
 
-def user_noop_filter(*args):
-    pass
-
-
 def test_user_name_conflict_during_creation_from_valid_data_is_handled(
-    user, dynamic_settings
+    user, dynamic_settings, disable_user_data_filters
 ):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
-        # Custom filters disable build in filters
-        with patch(
-            "misago.oauth2.validation.oauth2_user_data_filters",
-            [user_noop_filter],
-        ):
-            get_user_from_data(
-                Mock(settings=dynamic_settings, user_ip="83.0.0.1"),
-                {
-                    "id": "1234",
-                    "name": user.username,
-                    "email": "test@example.com",
-                    "avatar": None,
-                },
-                {},
-            )
+        get_user_from_data(
+            Mock(settings=dynamic_settings, user_ip="83.0.0.1"),
+            {
+                "id": "1234",
+                "name": user.username,
+                "email": "test@example.com",
+                "avatar": None,
+            },
+            {},
+        )
 
     assert excinfo.value.error_list == [
         "Your username returned by the provider is not available for use on this site."

--- a/misago/oauth2/tests/test_user_data_filter.py
+++ b/misago/oauth2/tests/test_user_data_filter.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from ..validation import filter_user_data
 
 
@@ -204,78 +202,6 @@ def user_email_filter(request, user, user_data):
     }
 
 
-def test_new_user_data_is_filtered_using_custom_filters(db, request):
-    def user_is_none_filter(request, user, user_data):
-        assert user is None
-
-    with patch(
-        "misago.oauth2.validation.oauth2_user_data_filters",
-        [
-            user_request_filter,
-            user_is_none_filter,
-            user_id_filter,
-            user_name_filter,
-            user_email_filter,
-        ],
-    ):
-        filtered_data = filter_user_data(
-            request,
-            None,
-            {
-                "id": "1234",
-                "name": "New User",
-                "email": "oauth2@example.com",
-                "avatar": None,
-            },
-        )
-
-        assert filtered_data == {
-            "id": "4321",
-            "name": "resU weN",
-            "email": "filtered_oauth2@example.com",
-            "avatar": None,
-        }
-
-
-def test_existing_user_data_is_filtered_using_custom_filters(user, request):
-    def user_is_set_filter(request, user_obj, user_data):
-        assert user_obj == user
-        return {
-            "id": str(user_obj.id),
-            "name": user_data["name"],
-            "email": user_data["email"],
-            "avatar": user_data["avatar"],
-        }
-
-    with patch(
-        "misago.oauth2.validation.oauth2_user_data_filters",
-        [
-            user_request_filter,
-            user_is_set_filter,
-            user_id_filter,
-            user_name_filter,
-            user_email_filter,
-        ],
-    ):
-        filtered_data = filter_user_data(
-            request,
-            user,
-            {
-                "id": "1234",
-                "name": "New User",
-                "email": "oauth2@example.com",
-                "avatar": None,
-            },
-        )
-
-        assert filtered_data == {
-            "id": "".join(reversed(str(user.id))),
-            "name": "resU weN",
-            "email": "filtered_oauth2@example.com",
-            "avatar": None,
-        }
-
-
 def test_original_user_data_is_not_mutated_by_default_filters(user, request):
     user_data = {
         "id": "1234",
@@ -291,50 +217,6 @@ def test_original_user_data_is_not_mutated_by_default_filters(user, request):
         "email": "oauth2@example.com",
         "avatar": None,
     }
-
-    assert user_data == {
-        "id": "1234",
-        "name": "New User",
-        "email": "oauth2@example.com",
-        "avatar": None,
-    }
-
-
-def test_original_user_data_is_not_mutated_by_custom_filters(user, request):
-    def user_is_set_filter(request, user_obj, user_data):
-        assert user_obj == user
-        return {
-            "id": str(user_obj.id),
-            "name": user_data["name"],
-            "email": user_data["email"],
-            "avatar": user_data["avatar"],
-        }
-
-    user_data = {
-        "id": "1234",
-        "name": "New User",
-        "email": "oauth2@example.com",
-        "avatar": None,
-    }
-
-    with patch(
-        "misago.oauth2.validation.oauth2_user_data_filters",
-        [
-            user_request_filter,
-            user_is_set_filter,
-            user_id_filter,
-            user_name_filter,
-            user_email_filter,
-        ],
-    ):
-        filtered_data = filter_user_data(request, user, user_data)
-
-        assert filtered_data == {
-            "id": "".join(reversed(str(user.id))),
-            "name": "resU weN",
-            "email": "filtered_oauth2@example.com",
-            "avatar": None,
-        }
 
     assert user_data == {
         "id": "1234",

--- a/misago/oauth2/tests/test_user_data_validation.py
+++ b/misago/oauth2/tests/test_user_data_validation.py
@@ -48,7 +48,9 @@ def test_existing_user_valid_data_is_validated(user, dynamic_settings):
     }
 
 
-def test_error_was_raised_for_user_data_with_without_name(db, dynamic_settings):
+def test_error_was_raised_for_user_data_with_without_name(
+    db, dynamic_settings, disable_user_data_filters
+):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
         validate_user_data(
             Mock(settings=dynamic_settings),
@@ -70,7 +72,9 @@ def test_error_was_raised_for_user_data_with_without_name(db, dynamic_settings):
     ]
 
 
-def test_error_was_raised_for_user_data_with_invalid_name(db, dynamic_settings):
+def test_error_was_raised_for_user_data_with_invalid_name(
+    db, dynamic_settings, disable_user_data_filters
+):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
         validate_user_data(
             Mock(settings=dynamic_settings),

--- a/misago/oauth2/tests/test_user_data_validation.py
+++ b/misago/oauth2/tests/test_user_data_validation.py
@@ -1,7 +1,6 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
-from django.core.exceptions import ValidationError
 
 from ..exceptions import OAuth2UserDataValidationError
 from ..validation import validate_user_data
@@ -49,28 +48,19 @@ def test_existing_user_valid_data_is_validated(user, dynamic_settings):
     }
 
 
-def user_noop_filter(*args):
-    return None
-
-
 def test_error_was_raised_for_user_data_with_without_name(db, dynamic_settings):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
-        # Custom filters disable build in filters
-        with patch(
-            "misago.oauth2.validation.oauth2_user_data_filters",
-            [user_noop_filter],
-        ):
-            validate_user_data(
-                Mock(settings=dynamic_settings),
-                None,
-                {
-                    "id": "1234",
-                    "name": "",
-                    "email": "user@example.com",
-                    "avatar": None,
-                },
-                {},
-            )
+        validate_user_data(
+            Mock(settings=dynamic_settings),
+            None,
+            {
+                "id": "1234",
+                "name": "",
+                "email": "user@example.com",
+                "avatar": None,
+            },
+            {},
+        )
 
     assert excinfo.value.error_list == [
         (
@@ -82,22 +72,17 @@ def test_error_was_raised_for_user_data_with_without_name(db, dynamic_settings):
 
 def test_error_was_raised_for_user_data_with_invalid_name(db, dynamic_settings):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
-        # Custom filters disable build in filters
-        with patch(
-            "misago.oauth2.validation.oauth2_user_data_filters",
-            [user_noop_filter],
-        ):
-            validate_user_data(
-                Mock(settings=dynamic_settings),
-                None,
-                {
-                    "id": "1234",
-                    "name": "Invalid!",
-                    "email": "user@example.com",
-                    "avatar": None,
-                },
-                {},
-            )
+        validate_user_data(
+            Mock(settings=dynamic_settings),
+            None,
+            {
+                "id": "1234",
+                "name": "Invalid!",
+                "email": "user@example.com",
+                "avatar": None,
+            },
+            {},
+        )
 
     assert excinfo.value.error_list == [
         (
@@ -109,22 +94,17 @@ def test_error_was_raised_for_user_data_with_invalid_name(db, dynamic_settings):
 
 def test_error_was_raised_for_user_data_with_too_long_name(db, dynamic_settings):
     with pytest.raises(OAuth2UserDataValidationError) as excinfo:
-        # Custom filters disable build in filters
-        with patch(
-            "misago.oauth2.validation.oauth2_user_data_filters",
-            [user_noop_filter],
-        ):
-            validate_user_data(
-                Mock(settings=dynamic_settings),
-                None,
-                {
-                    "id": "1234",
-                    "name": "UserName" * 100,
-                    "email": "user@example.com",
-                    "avatar": None,
-                },
-                {},
-            )
+        validate_user_data(
+            Mock(settings=dynamic_settings),
+            None,
+            {
+                "id": "1234",
+                "name": "UserName" * 100,
+                "email": "user@example.com",
+                "avatar": None,
+            },
+            {},
+        )
 
     assert excinfo.value.error_list == [
         "Username cannot be longer than 200 characters."
@@ -163,52 +143,3 @@ def test_error_was_raised_for_user_data_with_invalid_email(db, dynamic_settings)
         )
 
     assert excinfo.value.error_list == ["Enter a valid e-mail address."]
-
-
-def custom_oauth2_validator(request, user, user_data, raw_data):
-    if "bad" in user_data["name"].lower():
-        raise ValidationError("Custom validation error!")
-
-
-def test_custom_oauth2_validator_passes_valid_data(db, dynamic_settings):
-    user_data = {
-        "id": "1234",
-        "name": "UserName",
-        "email": "user@example.com",
-        "avatar": None,
-    }
-
-    with patch(
-        "misago.oauth2.validation.oauth2_validators",
-        [custom_oauth2_validator],
-    ):
-        assert (
-            validate_user_data(
-                Mock(settings=dynamic_settings),
-                None,
-                user_data,
-                {},
-            )
-            == user_data
-        )
-
-
-def test_custom_oauth2_validator_raises_error_for_invalid_data(db, dynamic_settings):
-    with pytest.raises(OAuth2UserDataValidationError) as excinfo:
-        with patch(
-            "misago.oauth2.validation.oauth2_validators",
-            [custom_oauth2_validator],
-        ):
-            validate_user_data(
-                Mock(settings=dynamic_settings),
-                None,
-                {
-                    "id": "1234",
-                    "name": "UserNameBad",
-                    "email": "user@example.com",
-                    "avatar": None,
-                },
-                {},
-            )
-
-    assert excinfo.value.error_list == ["Custom validation error!"]

--- a/misago/plugins/outlets.py
+++ b/misago/plugins/outlets.py
@@ -23,6 +23,8 @@ class PluginOutletHookAction:
 
 
 class PluginOutletHook(ActionHook[PluginOutletHookAction]):
+    __slots__ = ActionHook.__slots__
+
     def __call__(self, context: dict | Context) -> List[str | SafeString | None]:
         return super().__call__(context)
 


### PR DESCRIPTION
This PR replaces old filtering and validation hooks in `misago.oauth2` app with new ones.

This PR's goal is to add some hooks using new implementation to Misago, so I can write documentation generation for hooks reference later.

Related to the #1524 epic