### PR TITLE
Discover plugins urls

### DIFF
--- a/dev-docs/notifications.md
+++ b/dev-docs/notifications.md
@@ -69,7 +69,7 @@ notify_user(
 ```
 
 
-## Adding custom notification
+## Adding custom notifications
 
 Misago supports adding custom notifications for new events by plugins.
 

--- a/dev-docs/plugins/extending-misago.md
+++ b/dev-docs/plugins/extending-misago.md
@@ -44,7 +44,7 @@ The following models currently define this field:
 
 ## Urls
 
-Plugin [`urls`](https://docs.djangoproject.com/en/5.0/topics/http/urls/#example) modules are automatically [included](https://docs.djangoproject.com/en/5.0/topics/http/urls/#including-other-urlconfs) in the site's urlcofn before `misago.urls`.
+Plugin [`urls`](https://docs.djangoproject.com/en/5.0/topics/http/urls/#example) modules are automatically [included](https://docs.djangoproject.com/en/5.0/topics/http/urls/#including-other-urlconfs) in the site's `urlconf` before `misago.urls`.
 
 If both Misago and a plugin define a URL with the same path, the plugin's URL takes precedence over Misago's. This enables plugins to replace Misago's URLs and views.
 

--- a/dev-docs/plugins/extending-misago.md
+++ b/dev-docs/plugins/extending-misago.md
@@ -1,0 +1,59 @@
+# Extending Misago
+
+Misago defines a multiple extension points that plugin developers can use to add new features to Misago and extend or customize existing ones.
+
+
+## Plugins are Django applications
+
+Misago plugins are [Django applications](https://docs.djangoproject.com/en/5.0/ref/applications/) with some additional functionality.
+
+All standard Django extension points work out of the box in Misago plugins:
+
+- App config in the `apps.py` file.
+- Models defined in the `models.py` file.
+- Database migrations in the `migrations` directory.
+- Translations in the `locale` directory.
+- Templates in the `templates` directory.
+- Static files in the `static` directory.
+
+
+## Hooks
+
+Hooks are predefined locations in Misago's code where plugins can inject custom Python functions to execute as part of Misago's standard logic.
+
+- [Hooks guide](./hooks/index.md)
+- [Built-in hook reference](./hooks/reference.md)
+
+
+## Plugin data
+
+Some of Misago models have a special `plugin_data` JSON field that defaults to an empty JSON object (`{}`). This field can be used as a convenient storage space for plugins to store their data on Misago objects. Additionally, a GIN index is created on this field, allowing it to be [used in queries](https://docs.djangoproject.com/en/5.0/topics/db/queries/#querying-jsonfield).
+
+The following models currently define this field:
+
+- `misago.categories.models.Category`
+- `misago.threads.models.Attachment`
+- `misago.threads.models.AttachmentType`
+- `misago.threads.models.Poll`
+- `misago.threads.models.Post`
+- `misago.threads.models.Thread`
+- `misago.users.models.User`
+
+`plugin_data` is not a replacement for models. Use it for [denormalization](https://en.wikipedia.org/wiki/Denormalization), storing small bits of data that are frequently accessed or used in queries. 
+
+
+## Urls
+
+Plugin [`urls`](https://docs.djangoproject.com/en/5.0/topics/http/urls/#example) modules are automatically [included](https://docs.djangoproject.com/en/5.0/topics/http/urls/#including-other-urlconfs) in the site's urlcofn before `misago.urls`.
+
+If both Misago and a plugin define a URL with the same path, the plugin's URL takes precedence over Misago's. This enables plugins to replace Misago's URLs and views.
+
+By default, included plugin URLs are not namespaced. If you want your plugin's URLs to be namespaced, you need to [define the namespace](https://docs.djangoproject.com/en/5.0/topics/http/urls/#url-namespaces-and-included-urlconfs) in your plugin's URLs module.
+
+
+## Notifications
+
+The Notifications document provides a guide for adding custom notifications to Misago:
+
+[Adding custom notifications](../notifications.md#adding-custom-notification)
+

--- a/dev-docs/plugins/index.md
+++ b/dev-docs/plugins/index.md
@@ -2,55 +2,65 @@
 
 Misago implements a plugin system that enables customization and extension of the core functionality of the software.
 
-> **Plugins vs forking Misago**
->
-> It may seem simpler (and faster) to fork and change Misago directly instead of using a plugins. While this is possible, the time required to later keep the fork in sync with new versions of Misago for every site update may quickly add up, resulting in a net loss of time.
->
-> It is recommended to attempt achieving as much as possible through plugins. In situations where this is not feasible, consider [reaching out to the developers](https://misago-project.org/c/development/31/) before resorting to forking. Misago's current extension points list is not complete, and new ones may be added in future releases based on user feedback.
+
+## Installing plugins
+
+The default Misago setup supports installing plugins from both PyPI and the filesystem.
 
 
-## Plugin installation
+### Installing a plugin from PyPI
 
-To install a plugin, place its directory in the standard `plugins` directory within your Misago setup.
+To install a plugin from PyPI, first, create a `pip-install.txt` file in your Misago's `plugins` directory.
 
-Example plugin must be a directory containing a valid Python package with a `misago_plugin.py` file.
-
-This graph shows the file structure of a minimal valid plugin:
+Inside this file, specify each plugin to install from PyPI on a separate line:
 
 ```
-- minimal-plugin
-  - minimal_plugin
-    - __init__.py
-    - misago_plugin.py
+# pip-install.txt
+misago-first-plugin
+misago-other-plugin~=3.0
 ```
 
-Minimal plugin has:
+`pip-install.txt` a [PIP requirements file](https://pip.pypa.io/en/stable/reference/requirements-file-format/), but Misago only supports specifying package names and their versions (and comments). Other features like package URLs or installation options are not supported.
 
-- `minimal-plugin`: a directory that contains all the plugin's files.
-- `minimal_plugin`: a Python package (and a Django application) that Misago will import.
-- `__init__.py`: a file that makes `minimal_plugin` directory a Python package.
-- `misago_plugin.py`: a file that makes `minimal_plugin` directory a Misago plugin.
-
-The  `minimal-plugin` and `minimal_plugin` directories can contain additional files and directories. The `minimal-plugin` directory may include a `pyproject.toml` or `requirements.txt` file to define the plugin's dependencies. It could also include a hidden `.git` directory if plugin was cloned from a Git repository.
-
-Plugins following the above file structure are discovered and installed automatically at the Misago's Docker image build time.
+To install the specified plugins, [rebuild and restart the Docker container](./#rebuilding-misago-docker-image-to-install-plugins).
 
 
-## Writing custom plugin
+### Installing a plugin from the filesystem
 
-- django applications mechanism
-- plugin structure
+To install a plugin from the filesystem, place its directory in your Misago's `plugins` directory.
+
+A plugin must be a directory containing a Python package with a `misago_plugin.py` file:
+
+```
+example-plugin/
+  example_plugin/
+    __init__.py
+    misago_plugin.py
+```
+
+A valid plugin has:
+
+- `example-plugin`: a directory containing all the plugin's files.
+- `example_plugin`: a Python package (and a Django application) that Misago will import.
+- `__init__.py`: a file that makes the `example_plugin` directory a Python package.
+- `misago_plugin.py`: a file that makes the `example_plugin` directory a Misago plugin.
+
+The `example-plugin` directory may include a `pyproject.toml` or `requirements.txt` file to define the plugin's dependencies. It could also include a hidden `.git` directory if the plugin was cloned from a Git repository.
+
+Plugins following the above file structure are automatically discovered and installed during [the Misago Docker image build](./#rebuilding-misago-docker-image-to-install-plugins).
 
 
-## Plugin data
+## Rebuilding Misago Docker image to install plugins
 
-- explain what `plugin-data` model field is
-- generated list plugin data models
+Plugins are installed during the Misago Docker image build.
+
+If you are using [`misago-docker`](https://github.com/rafalp/misago-docker) to run your site, use the `./appctl rebuild` command.
+
+If you are using the [local development setup](https://github.com/rafalp/misago), run the `./dev rebuild` command instead.
 
 
-## Hooks
+## Creating a custom plugin
 
-Hooks are predefined locations in Misago's code where plugins can inject custom Python functions to execute as part of Misago's standard logic.
+If you are interested in creating a custom plugin, please see the [plugin tutorial](./plugin-development.md).
 
-- [Hooks guide](./hooks/index.md)
-- [Built-in hook reference](./hooks/reference.md)
+Once you have your basic plugin up and running, the [extending Misago](./extending-misago.md) document contains a list of all available extension points.

--- a/dev-docs/plugins/plugin-development.md
+++ b/dev-docs/plugins/plugin-development.md
@@ -1,0 +1,3 @@
+# Plugin dev tutorial
+
+TODO

--- a/devproject/urls.py
+++ b/devproject/urls.py
@@ -23,6 +23,7 @@ from django.views.decorators.http import last_modified
 from django.views.i18n import JavaScriptCatalog
 
 from misago import __released__, __version__
+from misago.plugins.urlpatterns import discover_plugins_urlpatterns
 from misago.users.forms.auth import AdminAuthenticationForm
 
 
@@ -40,7 +41,7 @@ admin.autodiscover()
 admin.site.login_form = AdminAuthenticationForm
 
 
-urlpatterns = [
+urlpatterns = discover_plugins_urlpatterns(settings.INSTALLED_PLUGINS) + [
     path("", include("misago.urls", namespace="misago")),
     # Javascript translations
     path(

--- a/misago/hooks.py
+++ b/misago/hooks.py
@@ -1,5 +1,4 @@
 apipatterns = []
-urlpatterns = []
 context_processors = []
 
 new_registrations_validators = []

--- a/misago/plugins/tests/test_discover_plugins_urls.py
+++ b/misago/plugins/tests/test_discover_plugins_urls.py
@@ -1,0 +1,11 @@
+from ..urlpatterns import discover_plugins_urlpatterns
+
+
+def test_discover_plugins_urlpatterns_discovers_apps_with_urls():
+    urlpatterns = discover_plugins_urlpatterns(["misago.threads", "misago.users"])
+    assert len(urlpatterns) == 2
+
+
+def test_discover_plugins_urlpatterns_skips_apps_without_urls():
+    urlpatterns = discover_plugins_urlpatterns(["misago.core"])
+    assert not urlpatterns

--- a/misago/plugins/urlpatterns.py
+++ b/misago/plugins/urlpatterns.py
@@ -1,0 +1,16 @@
+from importlib.util import find_spec
+
+from django.urls import URLResolver, include, path
+
+
+def discover_plugins_urlpatterns(plugins: list[str]) -> list[URLResolver]:
+    urlpatterns: list[URLResolver] = []
+    for plugin in plugins:
+        if plugin_has_urls(plugin):
+            urlpatterns.append(path("", include(f"{plugin}.urls")))
+
+    return urlpatterns
+
+
+def plugin_has_urls(plugin: str) -> bool:
+    return bool(find_spec(f"{plugin}.urls"))

--- a/misago/urls.py
+++ b/misago/urls.py
@@ -8,7 +8,7 @@ from .core.views import forum_index
 app_name = "misago"
 
 # Register Misago Apps
-urlpatterns = hooks.urlpatterns + [
+urlpatterns = [
     path("", include("misago.analytics.urls")),
     path("", include("misago.legal.urls")),
     path("", include("misago.users.urls")),


### PR DESCRIPTION
This PR adds a discovery of `urls` modules in plugins. Discovered `urls` are included in the `urlpatterns` used by the Misago site (not misago itself).

This PR also removes `urlpatterns` legacy hook.

# TODO

- [x] Discover plugins urls
- [x] Tests
- [x] Docs

Part of the #1524 epic