### PR TITLE
Template outlets docs and `template_outlet_action` util

### DIFF
--- a/dev-docs/plugins/extending-misago.md
+++ b/dev-docs/plugins/extending-misago.md
@@ -51,37 +51,12 @@ Hooks are predefined locations in Misago's code where plugins can inject custom 
 - [Built-in hook reference](./hooks/reference.md)
 
 
-## Plugin data
+## Template outlets
 
-Some of Misago models have a special `plugin_data` JSON field that defaults to an empty JSON object (`{}`). This field can be used as a convenient storage space for plugins to store their data on Misago objects. Additionally, a GIN index is created on this field, allowing it to be [used in queries](https://docs.djangoproject.com/en/5.0/topics/db/queries/#querying-jsonfield).
+Template outlets are special hooks located in Misago's templates where plugins can include extra HTML.
 
-The following models currently define this field:
-
-- `misago.categories.models.Category`
-- `misago.threads.models.Attachment`
-- `misago.threads.models.AttachmentType`
-- `misago.threads.models.Poll`
-- `misago.threads.models.Post`
-- `misago.threads.models.Thread`
-- `misago.users.models.User`
-
-`plugin_data` is not a replacement for models. Use it for [denormalization](https://en.wikipedia.org/wiki/Denormalization), storing small bits of data that are frequently accessed or used in queries. 
-
-
-## URLs
-
-Plugin [`urls`](https://docs.djangoproject.com/en/5.0/topics/http/urls/#example) modules are automatically [included](https://docs.djangoproject.com/en/5.0/topics/http/urls/#including-other-urlconfs) in the site's `urlconf` before `misago.urls`.
-
-If both Misago and a plugin define a URL with the same path, the plugin's URL takes precedence over Misago's. This enables plugins to replace Misago's URLs and views.
-
-By default, included plugin URLs are not namespaced. If you want your plugin's URLs to be namespaced, you need to [define the namespace](https://docs.djangoproject.com/en/5.0/topics/http/urls/#url-namespaces-and-included-urlconfs) in your plugin's URLs module.
-
-
-## Notifications
-
-The Notifications document provides a guide for adding custom notifications to Misago:
-
-[Adding custom notifications](../notifications.md#adding-custom-notification)
+- [Template outlets guide](./template-outlets.md)
+- [Built-in template outlets reference](./template-outlets-reference.md)
 
 
 ## Templates
@@ -116,3 +91,36 @@ my_plugin/
 ```
 
 Note that site owners can still override Misago and plugin templates through the `theme/templates` directory, which is part of the `misago-docker` setup.
+
+
+## Plugin data
+
+Some of Misago models have a special `plugin_data` JSON field that defaults to an empty JSON object (`{}`). This field can be used as a convenient storage space for plugins to store their data on Misago objects. Additionally, a GIN index is created on this field, allowing it to be [used in queries](https://docs.djangoproject.com/en/5.0/topics/db/queries/#querying-jsonfield).
+
+The following models currently define this field:
+
+- `misago.categories.models.Category`
+- `misago.threads.models.Attachment`
+- `misago.threads.models.AttachmentType`
+- `misago.threads.models.Poll`
+- `misago.threads.models.Post`
+- `misago.threads.models.Thread`
+- `misago.users.models.User`
+
+`plugin_data` is not a replacement for models. Use it for [denormalization](https://en.wikipedia.org/wiki/Denormalization), storing small bits of data that are frequently accessed or used in queries. 
+
+
+## URLs
+
+Plugin [`urls`](https://docs.djangoproject.com/en/5.0/topics/http/urls/#example) modules are automatically [included](https://docs.djangoproject.com/en/5.0/topics/http/urls/#including-other-urlconfs) in the site's `urlconf` before `misago.urls`.
+
+If both Misago and a plugin define a URL with the same path, the plugin's URL takes precedence over Misago's. This enables plugins to replace Misago's URLs and views.
+
+By default, included plugin URLs are not namespaced. If you want your plugin's URLs to be namespaced, you need to [define the namespace](https://docs.djangoproject.com/en/5.0/topics/http/urls/#url-namespaces-and-included-urlconfs) in your plugin's URLs module.
+
+
+## Notifications
+
+The Notifications document provides a guide for adding custom notifications to Misago:
+
+[Adding custom notifications](../notifications.md#adding-custom-notification)

--- a/dev-docs/plugins/template-outlets-reference.md
+++ b/dev-docs/plugins/template-outlets-reference.md
@@ -1,0 +1,28 @@
+# Built-in template outlets reference
+
+This document contains a list of all built-in template outlets in Misago.
+
+
+## `ADMIN_DASHBOARD_AFTER_ANALYTICS`
+
+On the Admin Dashboard page, below the Analytics card.
+
+
+## `ADMIN_DASHBOARD_AFTER_CHECKS`
+
+On the Admin Dashboard page, below the Checks card.
+
+
+## `ADMIN_DASHBOARD_END`
+
+On the Admin Dashboard page, below all other content.
+
+
+## `ADMIN_DASHBOARD_START`
+
+On the Admin Dashboard page, above all other content.
+
+
+## `TEST`
+
+Used in some tests.

--- a/dev-docs/plugins/template-outlets.md
+++ b/dev-docs/plugins/template-outlets.md
@@ -103,8 +103,7 @@ def display_forum_stats(context: Context) -> str:
         "users": User.objects.count(),
     }
 
-    with context.update(forum_stats) as new_context:
-        return render_to_string("my_plugin/forum_stats.html", new_context)
+    return render_to_string("my_plugin/forum_stats.html", forum_stats)
 ```
 
 
@@ -156,7 +155,7 @@ from misago.users.models import User
 
 
 @template_outlet_action
-def display_forum_stats(context: Context) -> Tuple[str, dict]:
+def display_forum_stats(context: Context) -> Tuple[str, dict] | None:
     # Hide forum stats from unregistered users
     if context["user"].is_anonymous:
         return None

--- a/dev-docs/plugins/template-outlets.md
+++ b/dev-docs/plugins/template-outlets.md
@@ -1,0 +1,302 @@
+# Template outlets
+
+Template outlets are special hooks located in Misago's templates where plugins can include extra HTML.
+
+
+## Template outlet function
+
+Functions registered in template outlets are called with a single argument: a `django.template.Context` instance, and return either a `str` or `SafeText`:
+
+```python
+from django.template import Context
+from django.utils.html import format_html
+from django.utils.safestring import SafeText
+
+from misago.threads.models import Post, Thread
+from misago.users.models import User
+
+
+def display_forum_stats(context: Context) -> SafeText:
+    return format_html(
+        (
+            "<ul class=\"forum-stats\">"
+            "<li>Threads: <strong>{}</strong></li>"
+            "<li>Posts: <strong>{}</strong></li>"
+            "<li>Users: <strong>{}</strong></li>"
+            "</ul>"
+        ),
+        Thread.objects.count(),
+        Post.objects.count(),
+        User.objects.count(),
+    )
+```
+
+
+### Conditional rendering
+
+A function can return `None` to don't render anything in a template outlet:
+
+```python
+from django.template import Context
+from django.utils.html import format_html
+from django.utils.safestring import SafeText
+
+from misago.threads.models import Post, Thread
+from misago.users.models import User
+
+
+def display_forum_stats(context: Context) -> SafeText | None:
+    # Hide forum stats from unregistered users
+    if context["user"].is_anonymous:
+        return None
+
+    return format_html(
+        (
+            "<ul class=\"forum-stats\">"
+            "<li>Threads: <strong>{}</strong></li>"
+            "<li>Posts: <strong>{}</strong></li>"
+            "<li>Users: <strong>{}</strong></li>"
+            "</ul>"
+        ),
+        Thread.objects.count(),
+        Post.objects.count(),
+        User.objects.count(),
+    )
+```
+
+
+### Automatic escaping
+
+If the function returns a `str`, it will be automatically escaped before its insertion in a template:
+
+```python
+def display_hello_message(context: Context) -> str:
+    return (
+        f"<div class=\"alert alert-info\">Welcome, {context['user'].username}!</div>"
+    )
+```
+
+Produces escaped HTML:
+
+```html
+&lt;div class=&quot;alert alert-info&quot;&gt;Welcome, John!&lt;/div&gt;
+```
+
+To prevent this escaping, use the [`format_html`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.html.format_html) and [`mark_safe`](https://docs.djangoproject.com/en/5.0/ref/utils/#django.utils.safestring.mark_safe) utilities from Django.
+
+Especially, `mark_safe` is useful if your function renders a template as its output:
+
+```python
+from django.template import Context
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from misago.threads.models import Post, Thread
+from misago.users.models import User
+
+
+@mark_safe
+def display_forum_stats(context: Context) -> str:
+    forum_stats = {
+        "threads": Thread.objects.count(),
+        "posts": Post.objects.count(),
+        "users": User.objects.count(),
+    }
+
+    with context.update(forum_stats) as new_context:
+        return render_to_string("my_plugin/forum_stats.html", new_context)
+```
+
+
+## `template_outlet_action` decorator
+
+The `display_forum_stats` function from the previous section can be simplified with the `template_outlet_action` decorator:
+
+```python
+from typing import Tuple
+
+from django.template import Context
+
+from misago.plugins.outlets import template_outlet_action
+from misago.threads.models import Attachment, Post, Thread
+from misago.users.models import User
+
+
+@template_outlet_action
+def display_forum_stats(context: Context) -> Tuple[str, dict]:
+    return (
+        "my_plugin/forum_stats.html",
+        {
+            "threads": Thread.objects.count(),
+            "posts": Post.objects.count(),
+            "users": User.objects.count(),
+        }
+    )
+```
+
+`template_outlet_action` behaves differently based on the return value of the decorated function:
+
+If a function returns a `str`, this string is used as the template name, which is then rendered with the unchanged context.
+
+If a tuple of `str` and `dict` is returned, the string is used as a template name, and the dictionary is used to update the context before rendering the template.
+
+If `None` is returned, nothing is rendered.
+
+This enables advanced use cases:
+
+```python
+from typing import Tuple
+
+from django.template import Context
+
+import misago
+from misago.plugins.outlets import template_outlet_action
+from misago.threads.models import Post, Thread
+from misago.users.models import User
+
+
+@template_outlet_action
+def display_forum_stats(context: Context) -> Tuple[str, dict]:
+    # Hide forum stats from unregistered users
+    if context["user"].is_anonymous:
+        return None
+
+    forum_stats = {
+        "threads": Thread.objects.count(),
+        "posts": Post.objects.count(),
+        "users": User.objects.count(),
+    }
+
+    # Display full forum stats for admins
+    if context["user"].is_staff:
+        forum_stats.update({
+            "attachments": Attachment.objects.count(),
+            "misago": misago.__version__,
+        })
+        return ("my_plugin/forum_stats_admins.html", forum_stats)
+
+    return ("my_plugin/forum_stats.html", forum_stats)
+```
+
+
+## Registering a function in an outlet
+
+To register a function in a template outlet, use the `append_outlet_action` or `prepend_outlet_action` functions from the `misago.plugins.outlets` module:
+
+```python
+from misago.plugins.outlets import append_outlet_action
+
+
+def display_forum_stats(context: Context):
+    ...
+
+
+append_outlet_action("OUTLET_NAME", display_forum_stats)
+```
+
+
+### `append_outlet_action`
+
+```python
+def append_outlet_action(
+    outlet_name: str | PluginOutlet,
+    function: Callable[[Context], str | SafeText],
+):
+    ...
+```
+
+This function registers a `function` at the end of the functions list for the `outlet_name` outlet.
+
+
+### `prepend_outlet_action`
+
+```python
+def prepend_outlet_action(
+    outlet_name: str | PluginOutlet,
+    function: Callable[[Context], str | SafeText],
+):
+    ...
+```
+
+This function registers a `function` at the start of the functions list for the `outlet_name` outlet.
+
+
+## Built-in template outlets
+
+A list of all built-in template outlets generated from the Misago source code is available in a separate document:
+
+[Built-in template outlets reference](./template-outlets-reference.md)
+
+
+## Template tags
+
+Template outlets in templates are realized with two template tags, loadable from `misago_plugins`.
+
+
+### `pluginoutlet`
+
+The `{% pluginoutlet OUTLET %}` template tag calls functions registered with the `OUTLET` template outlet and inserts the `str` and `SafeText` returned from them in the rendered template:
+
+```html
+{% load misago_plugins %}
+
+{% pluginoutlet OUTLET %}
+```
+
+
+### `hasplugins`
+
+The `{% hasplugins OUTLET %}` template tag works like Django's standard `{% if CONDITION %}` tag but only renders content if the specified template outlet has any functions registered with it.
+
+Sample usage:
+
+```html
+{% load misago_plugins %}
+
+{% hasplugins OUTLET %}
+    <div class="plugin-menu">{% pluginoutlet OUTLET %}</div>
+{% endhasplugins %}
+```
+
+The `{% else %}` clause is also supported for displaying alternative content if no functions are registered with the outlet:
+
+```html
+{% load misago_plugins %}
+
+{% hasplugins OUTLET %}
+    <div class="plugin-menu">{% pluginoutlet OUTLET %}</div>
+{% else %}
+    <div class="plugin-menu-disabled">This menu is not available</div>
+{% endhasplugins %}
+```
+
+
+## Adding new template outlets
+
+To create a new template outlet, use the `create_new_outlet` function from the `misago.plugins.outlets` module:
+
+```python
+from misago.plugins.outlets import create_new_outlet
+
+create_new_outlet("MY_OUTLET")
+```
+
+Next, insert a `{% pluginoutlet MY_OUTLET %}` tag in a template:
+
+```html
+{% load misago_plugins %}
+<!-- Some template content -->
+{% pluginoutlet MY_OUTLET %}
+<!-- Other template content -->
+```
+
+If you are contributing a new outlet in a pull request to Misago, instead of using `create_new_outlet`, update the `PluginOutlet` enumerable defined in `misago.plugins.enums`:
+
+```python
+class PluginOutlet(Enum):
+    # ...
+
+    NEW_OUTLET = "Short note describing new outlet's location."
+```
+
+Misago's default template outlets are automatically created from this enumerable.

--- a/generate_dev_docs.py
+++ b/generate_dev_docs.py
@@ -1,10 +1,12 @@
 # Script for generating some of documents in `dev-docs` from Misago's code
 import ast
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 from textwrap import dedent, indent
 
 HOOKS_MODULES = ("misago.oauth2.hooks",)
+OUTLETS_ENUM = "misago.plugins.enums.PluginOutlet"
 
 BASE_PATH = Path(__file__).parent
 DOCS_PATH = BASE_PATH / "dev-docs"
@@ -14,6 +16,7 @@ PLUGINS_HOOKS_PATH = PLUGINS_PATH / "hooks"
 
 def main():
     generate_hooks_reference()
+    generate_outlets_reference()
 
 
 def generate_hooks_reference():
@@ -246,6 +249,24 @@ def parse_hook_docstring(docstring: str) -> HookDocstring:
             description = block
 
     return HookDocstring(description=description, examples=examples or None)
+
+
+def generate_outlets_reference():
+    outlets_path, outlets_attr = OUTLETS_ENUM.rsplit(".", 1)
+    outlets_enum = getattr(import_module(outlets_path), outlets_attr)
+    outlets_dict = {outlet.name: outlet.value for outlet in outlets_enum}
+    
+    with open(PLUGINS_PATH / "template-outlets-reference.md", "w") as fp:
+        fp.write("# Built-in template outlets reference")
+        fp.write("\n\n")
+        fp.write(
+            "This document contains a list of all built-in template outlets in Misago."
+        )
+        for outlet_name in sorted(outlets_dict):
+            fp.write("\n\n\n")
+            fp.write(f"## `{outlet_name}`")
+            fp.write("\n\n")
+            fp.write(outlets_dict[outlet_name])
 
 
 def get_callable_class_signature(class_def: ast.ClassDef) -> tuple[str, str | None]:

--- a/generate_dev_docs.py
+++ b/generate_dev_docs.py
@@ -255,7 +255,7 @@ def generate_outlets_reference():
     outlets_path, outlets_attr = OUTLETS_ENUM.rsplit(".", 1)
     outlets_enum = getattr(import_module(outlets_path), outlets_attr)
     outlets_dict = {outlet.name: outlet.value for outlet in outlets_enum}
-    
+
     with open(PLUGINS_PATH / "template-outlets-reference.md", "w") as fp:
         fp.write("# Built-in template outlets reference")
         fp.write("\n\n")

--- a/misago/plugins/enums.py
+++ b/misago/plugins/enums.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class PluginOutlet(Enum):
+    """Enum with standard plugin outlets defined by Misago.
+
+    Members values are descriptions of outlets locations, used by the docs generator.
+    """
+
+    TEST = "Used in some tests."
+    ADMIN_DASHBOARD_START = "On the Admin Dashboard page, above all other content."
+    ADMIN_DASHBOARD_AFTER_CHECKS = "On the Admin Dashboard page, below the Checks card."
+    ADMIN_DASHBOARD_AFTER_ANALYTICS = (
+        "On the Admin Dashboard page, below the Analytics card."
+    )
+    ADMIN_DASHBOARD_END = "On the Admin Dashboard page, below all other content."

--- a/misago/plugins/outlets.py
+++ b/misago/plugins/outlets.py
@@ -67,22 +67,24 @@ def template_outlet_action(f):
             return ""
 
         if isinstance(template_data, str):
-            return _render_template(template_data, context)
+            return _include_template(template_data, context)
 
         if isinstance(template_data, tuple):
             template_name, new_context = template_data
-            return _render_template(template_name, context, new_context)
+            return _include_template(template_name, context, new_context)
 
         return ""
 
     return wrapped_outlet_action
 
 
-def _render_template(
+def _include_template(
     template_name: str, context: Context, new_context: dict | None = None
 ):
-    # Template inclusion logic inspired by Django's include tag
-    # This logic is Django-specific and doesn't work with other template engines
+    """Subset of Django include template tag.
+    
+    Works only with Django template engine.
+    """
     cache = context.render_context.dicts[0].setdefault("_template_outlet_action", {})
     template = cache.get(template_name)
     if template is None:

--- a/misago/plugins/outlets.py
+++ b/misago/plugins/outlets.py
@@ -81,7 +81,7 @@ def _include_template(
     template_name: str, context: Context, new_context: dict | None = None
 ):
     """Subset of Django include template tag.
-    
+
     Works only with Django template engine.
     """
     cache = context.render_context.dicts[0].setdefault("_template_outlet_action", {})

--- a/misago/plugins/outlets.py
+++ b/misago/plugins/outlets.py
@@ -1,15 +1,14 @@
 from functools import wraps
-from typing import Any, Dict, List, Protocol
+from typing import Dict, List, Protocol
 
 from django.template import Context
-from django.template.loader import render_to_string
 from django.utils.safestring import SafeString, mark_safe
 
 from .enums import PluginOutlet
 from .hooks import ActionHook
 
 
-class PluginOutletHookAction:
+class PluginOutletHookAction(Protocol):
     def __call__(self, context: dict | Context) -> str | SafeString | None:
         pass
 

--- a/misago/plugins/templates/misago/template_outlet_action_test.html
+++ b/misago/plugins/templates/misago/template_outlet_action_test.html
@@ -1,0 +1,1 @@
+<div>Plugin returned message: {{ message }}</div>

--- a/misago/plugins/tests/__snapshots__/test_template_outlet_action.ambr
+++ b/misago/plugins/tests/__snapshots__/test_template_outlet_action.ambr
@@ -1,0 +1,10 @@
+# serializer version: 1
+# name: test_noop_template_action_renders_nothing
+  '<div></div>'
+# ---
+# name: test_template_name_action_renders_template_with_standard_context
+  '<div><div>Plugin returned message: Standard context</div></div>'
+# ---
+# name: test_template_name_context_action_renders_template_with_updated_context
+  '<div><div>Plugin returned message: Custom context</div></div>'
+# ---

--- a/misago/plugins/tests/conftest.py
+++ b/misago/plugins/tests/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+from django.template import Context, Template
+
+from ..outlets import PluginOutletHook, template_outlets
+
+
+@pytest.fixture
+def patch_outlets():
+    try:
+        org_outlets = template_outlets.copy()
+        for key in template_outlets:
+            template_outlets[key] = PluginOutletHook()
+        yield template_outlets
+    finally:
+        for key, hook in org_outlets.items():
+            template_outlets[key] = hook
+
+
+@pytest.fixture
+def render_outlet_template():
+    def render_outlet_template_function(context: dict | None = None):
+        template = Template(
+            """
+            {% load misago_plugins %}
+            <div>{% pluginoutlet TEST %}</div>
+            """
+        )
+
+        return template.render(Context(context or {})).strip()
+
+    return render_outlet_template_function

--- a/misago/plugins/tests/test_template_outlet_action.py
+++ b/misago/plugins/tests/test_template_outlet_action.py
@@ -1,0 +1,40 @@
+from ..outlets import PluginOutlet, append_outlet_action, template_outlet_action
+
+
+@template_outlet_action
+def noop_action(context):
+    return None
+
+
+def test_noop_template_action_renders_nothing(
+    patch_outlets, render_outlet_template, snapshot
+):
+    append_outlet_action(PluginOutlet.TEST, noop_action)
+    html = render_outlet_template()
+    assert snapshot == html
+
+
+@template_outlet_action
+def template_name_action(context):
+    return "misago/template_outlet_action_test.html"
+
+
+def test_template_name_action_renders_template_with_standard_context(
+    patch_outlets, render_outlet_template, snapshot
+):
+    append_outlet_action(PluginOutlet.TEST, template_name_action)
+    html = render_outlet_template({"message": "Standard context"})
+    assert snapshot == html
+
+
+@template_outlet_action
+def template_name_context_action(context):
+    return "misago/template_outlet_action_test.html", {"message": "Custom context"}
+
+
+def test_template_name_context_action_renders_template_with_updated_context(
+    patch_outlets, render_outlet_template, snapshot
+):
+    append_outlet_action(PluginOutlet.TEST, template_name_context_action)
+    html = render_outlet_template({"message": "Standard context"})
+    assert snapshot == html


### PR DESCRIPTION
This PR adds `template_outlet_action` decorator for easy implementation of outlet actions.

It also updates dev docs with docs for template outlets.

Relates to #1524 epic