### PR TITLE
Sign-in with Discord

### DIFF
--- a/misago/socialauth/admin/forms/__init__.py
+++ b/misago/socialauth/admin/forms/__init__.py
@@ -1,4 +1,5 @@
 from .base import OAuthProviderForm, ProviderForm
+from .discord import DiscordForm
 from .facebook import FacebookForm
 from .github import GitHubForm
 from .google import GoogleForm

--- a/misago/socialauth/admin/forms/discord.py
+++ b/misago/socialauth/admin/forms/discord.py
@@ -1,0 +1,15 @@
+from django import forms
+from django.utils.translation import pgettext_lazy
+
+from .base import OAuthProviderForm
+
+
+class DiscordForm(OAuthProviderForm):
+    key = forms.CharField(
+        label=pgettext_lazy("admin social auth discord form", "App ID"),
+        required=False,
+    )
+    secret = forms.CharField(
+        label=pgettext_lazy("admin social auth discord form", "App Secret"),
+        required=False,
+    )

--- a/misago/socialauth/admin/tests/test_discord_form.py
+++ b/misago/socialauth/admin/tests/test_discord_form.py
@@ -1,0 +1,60 @@
+import pytest
+from django.urls import reverse
+
+from ...models import SocialAuthProvider
+
+
+admin_link = reverse("misago:admin:settings:socialauth:edit", kwargs={"pk": "discord"})
+
+
+@pytest.fixture
+def provider(db):
+    return SocialAuthProvider.objects.create(
+        provider="discord", is_active=True, order=0
+    )
+
+
+def test_discord_form_can_be_accessed(admin_client):
+    response = admin_client.get(admin_link)
+    assert response.status_code == 200
+
+
+def test_discord_login_can_be_setup(admin_client):
+    admin_client.post(
+        admin_link,
+        {
+            "is_active": "1",
+            "associate_by_email": "1",
+            "key": "test-key",
+            "secret": "test-secret",
+        },
+    )
+
+    provider = SocialAuthProvider.objects.get(provider="discord")
+    assert provider.is_active
+    assert provider.settings == {
+        "associate_by_email": 1,
+        "key": "test-key",
+        "secret": "test-secret",
+    }
+
+
+def test_discord_login_can_be_disabled(admin_client, provider):
+    admin_client.post(admin_link, {"is_active": "0"})
+
+    provider = SocialAuthProvider.objects.get(provider="discord")
+    assert not provider.is_active
+
+
+def test_discord_login_form_requires_key_to_setup(admin_client):
+    admin_client.post(admin_link, {"is_active": "1", "secret": "test-secret"})
+
+    with pytest.raises(SocialAuthProvider.DoesNotExist):
+        SocialAuthProvider.objects.get(provider="discord")
+
+
+def test_discord_login_form_requires_secret_to_setup(admin_client):
+    admin_client.post(admin_link, {"is_active": "1", "key": "test-key"})
+
+    with pytest.raises(SocialAuthProvider.DoesNotExist):
+        SocialAuthProvider.objects.get(provider="discord")

--- a/misago/socialauth/apps.py
+++ b/misago/socialauth/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from social_core.backends.discord import DiscordOAuth2
 from social_core.backends.facebook import FacebookOAuth2
 from social_core.backends.github import GithubOAuth2
 from social_core.backends.google import GoogleOAuth2
@@ -14,8 +15,16 @@ class MisagoSocialAuthConfig(AppConfig):
 
     def ready(self):
         # Register default providers
-        from .admin.forms import FacebookForm, GitHubForm, GoogleForm, TwitterForm
+        from .admin.forms import DiscordForm, FacebookForm, GitHubForm, GoogleForm, TwitterForm
 
+        providers.add(
+            provider="discord",
+            name="Discord",
+            auth_backend=DiscordOAuth2,
+            settings={"scope": ["email"]},
+            admin_form=DiscordForm,
+            admin_template="misago/admin/socialauth/form.html",
+        )
         providers.add(
             provider="facebook",
             name="Facebook",

--- a/misago/socialauth/apps.py
+++ b/misago/socialauth/apps.py
@@ -15,7 +15,13 @@ class MisagoSocialAuthConfig(AppConfig):
 
     def ready(self):
         # Register default providers
-        from .admin.forms import DiscordForm, FacebookForm, GitHubForm, GoogleForm, TwitterForm
+        from .admin.forms import (
+            DiscordForm,
+            FacebookForm,
+            GitHubForm,
+            GoogleForm,
+            TwitterForm,
+        )
 
         providers.add(
             provider="discord",


### PR DESCRIPTION
added discord sign in option 
Fixes https://github.com/rafalp/Misago/issues/1637

Added test cases 
tested the functionality 
Discord option is available on the "Setup new login method"
![image](https://github.com/rafalp/Misago/assets/15951170/7fc36aa7-2cbe-4383-aded-bb292ab8e362)

I have added Mesago to Discord. When registering the app on the discord to get client id and client secret, the redirect URL is set as below 
![image](https://github.com/rafalp/Misago/assets/15951170/71a83433-eacf-4477-90ad-8903507773d5)

Be careful to select `CLIENT ID` and `CLIENT SECRET`  (and not `PUBLIC KEY` accidentally) under `Client information` section in Discord. Its in `OAuth2` section in Discord. It won't be visible if you are looking at `General Information` section.

Once the App ID and secret are added to the settings the new option appears as shown below 
![image](https://github.com/rafalp/Misago/assets/15951170/6e1d12c7-b6a0-4232-99e4-50562356f952)



When users try to sign in or register they have the option to use discord 
![image](https://github.com/rafalp/Misago/assets/15951170/9e344a76-8dea-407b-97d3-b8187d2ec285)

![image](https://github.com/rafalp/Misago/assets/15951170/df9c0e37-30eb-42f9-b25c-d4350c28a33d)

the login option with Discord asks to authorize 
![image](https://github.com/rafalp/Misago/assets/15951170/7855515d-1425-4e66-a885-30f88661e297)

Once clicked Authorize, it logs in to Mesago as expected
![image](https://github.com/rafalp/Misago/assets/15951170/0251600c-2777-4ad7-b3c0-411741f4580a)
