### PR TITLE
Fix broken filters links on threads lists

### DIFF
--- a/misago/templates/misago/category/blankslate.html
+++ b/misago/templates/misago/category/blankslate.html
@@ -8,7 +8,7 @@
       {% endblocktrans %}
     </p>
     <div class="threads-list-blankslate-links">
-      <a class="btn btn-default" href="{{ threads.clear_filters_url }}">
+      <a class="btn btn-default" href="{{ threads.filters_clear_url }}">
         {% trans "Clear filters" context "threads list filter" %}
       </a>
     </div>

--- a/misago/templates/misago/private_threads/blankslate.html
+++ b/misago/templates/misago/private_threads/blankslate.html
@@ -8,7 +8,7 @@
       {% endblocktrans %}
     </p>
     <div class="threads-list-blankslate-links">
-      <a class="btn btn-default" href="{{ threads.clear_filters_url }}">
+      <a class="btn btn-default" href="{{ threads.filters_clear_url }}">
         {% trans "Clear filters" context "threads list filter" %}
       </a>
     </div>

--- a/misago/templates/misago/threads/blankslate.html
+++ b/misago/templates/misago/threads/blankslate.html
@@ -8,7 +8,7 @@
       {% endblocktrans %}
     </p>
     <div class="threads-list-blankslate-links">
-      <a class="btn btn-default" href="{{ threads.clear_filters_url }}">
+      <a class="btn btn-default" href="{{ threads.filters_clear_url }}">
         {% trans "Clear filters" context "threads list filter" %}
       </a>
     </div>

--- a/misago/templates/misago/threads/filters_dropdown.html
+++ b/misago/templates/misago/threads/filters_dropdown.html
@@ -16,7 +16,7 @@
   <ul class="dropdown-menu stick-to-bottom">
     {% if active_filter %}
       <li>
-        <a href="{{ threads.clear_filters_url }}">
+        <a href="{{ threads.filters_clear_url }}">
           {% trans "Clear filters" context "threads list filter" %}
         </a>
       </li>
@@ -46,7 +46,7 @@
     <ul class="dropdown-menu w-100-xs noscript-collapsible-items">
       {% if active_filter %}
         <li>
-          <a href="{{ threads.clear_filters_url }}">
+          <a href="{{ threads.filters_clear_url }}">
             {% trans "Clear filters" context "threads list filter" %}
           </a>
         </li>

--- a/misago/templates/misago/threads/filters_noscript.html
+++ b/misago/templates/misago/threads/filters_noscript.html
@@ -8,7 +8,7 @@
       <ul class="nav nav-pills" role="menu" itemscope="" itemtype="http://schema.org/SiteNavigationElement">
         {% if threads.active_filter %}
           <li>
-            <a href="{{ threads.clear_filters_url }}">
+            <a href="{{ threads.filters_clear_url }}">
               {% trans "Clear filters" context "threads list filter" %}
             </a>
           </li>

--- a/misago/threads/tests/test_threads_lists_views.py
+++ b/misago/threads/tests/test_threads_lists_views.py
@@ -432,11 +432,33 @@ def test_threads_list_raises_404_error_if_filter_is_invalid(
 @override_dynamic_settings(index_view="categories")
 def test_threads_list_filters_threads(default_category, user, user_client):
     visible_thread = post_thread(default_category, title="User Thread", poster=user)
-    hidden_thread = post_thread(default_category, title="Other Thread")
+    hidden_thread = post_thread(default_category, title="Hidden Thread")
 
     response = user_client.get(reverse("misago:threads", kwargs={"filter": "my"}))
     assert_contains(response, visible_thread.title)
     assert_not_contains(response, hidden_thread.title)
+
+
+@override_dynamic_settings(index_view="threads")
+def test_index_threads_list_filters_threads(default_category, user, user_client):
+    visible_thread = post_thread(default_category, title="User Thread", poster=user)
+    hidden_thread = post_thread(default_category, title="Hidden Thread")
+
+    response = user_client.get(reverse("misago:threads", kwargs={"filter": "my"}))
+    assert_contains(response, visible_thread.title)
+    assert_not_contains(response, hidden_thread.title)
+
+
+@override_dynamic_settings(index_view="categories")
+def test_threads_list_builds_valid_filters_urls(user_client):
+    response = user_client.get(reverse("misago:threads"))
+    assert_contains(response, reverse("misago:threads", kwargs={"filter": "my"}))
+
+
+@override_dynamic_settings(index_view="threads")
+def test_index_threads_list_builds_valid_filters_urls(user_client):
+    response = user_client.get(reverse("misago:index"))
+    assert_contains(response, reverse("misago:threads", kwargs={"filter": "my"}))
 
 
 def test_category_threads_list_raises_404_error_if_filter_is_invalid(

--- a/misago/threads/views/list.py
+++ b/misago/threads/views/list.py
@@ -484,17 +484,12 @@ class ThreadsListView(ListView):
                 }
             )
 
-        if request.settings.index_view == "threads":
-            clear_filters_url = reverse("misago:index")
-        else:
-            clear_filters_url = filters_base_url
-
         return {
             "template_name": self.threads_component_template_name,
             "latest_post": self.get_threads_latest_post_id(threads_list),
             "active_filter": active_filter,
             "filters": filters,
-            "clear_filters_url": clear_filters_url,
+            "filters_clear_url": self.get_filters_clear_url(request),
             "moderation_actions": self.get_moderation_actions(request),
             "items": items,
             "paginator": paginator,
@@ -506,6 +501,12 @@ class ThreadsListView(ListView):
 
     def get_filters_base_url(self) -> str:
         return reverse("misago:threads")
+
+    def get_filters_clear_url(self, request: HttpRequest) -> str:
+        if request.settings.index_view == "threads":
+            return reverse("misago:index")
+
+        return self.get_filters_base_url()
 
     def get_threads_filters(
         self, request: HttpRequest, base_url: str, filter: str | None
@@ -884,7 +885,7 @@ class CategoryThreadsListView(ListView):
             "latest_post": self.get_threads_latest_post_id(threads_list),
             "active_filter": active_filter,
             "filters": filters,
-            "clear_filters_url": filters_base_url,
+            "filters_clear_url": filters_base_url,
             "moderation_actions": self.get_moderation_actions(request, category),
             "items": items,
             "paginator": paginator,
@@ -1206,7 +1207,7 @@ class PrivateThreadsListView(ListView):
             "latest_post": self.get_threads_latest_post_id(threads_list),
             "active_filter": active_filter,
             "filters": filters,
-            "clear_filters_url": filters_base_url,
+            "filters_clear_url": filters_base_url,
             "items": items,
             "paginator": paginator,
             "enable_polling": self.is_threads_polling_enabled(request),


### PR DESCRIPTION
Misago builds invalid filters urls for main threads list if threads list is set as index page.

# TODO

- [x] Fix issue
- [x] Write tests