### PR TITLE
Add threads displaying different timestamps to dev fixture

### DIFF
--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+from random import randint
 from textwrap import dedent
 
 from django.contrib.auth import get_user_model
@@ -170,6 +172,191 @@ class Command(BaseCommand):
             .first()
         )
 
+        previous_year_timestamp = timestamp.replace(
+            year=timestamp.year - 1,
+            month=randint(1, 10),
+            day=randint(1, 28),
+            hour=randint(0, 23),
+            minute=randint(0, 59),
+            second=randint(0, 59),
+        )
+
+        previous_year_thread = Thread.objects.create(
+            category=first_category,
+            title="Thread with last activity from previous year",
+            slug="thread-with-last-activity-from-previous-year",
+            started_on=previous_year_timestamp,
+            last_post_on=previous_year_timestamp,
+            starter=None,
+            starter_name="Misago",
+            starter_slug="misago",
+            last_poster=None,
+            last_poster_name="Misago",
+            last_poster_slug="misago",
+        )
+        previous_year_post = Post.objects.create(
+            category=first_category,
+            thread=previous_year_thread,
+            poster=None,
+            poster_name="Misago",
+            posted_on=previous_year_timestamp,
+            updated_on=previous_year_timestamp,
+        )
+
+        previous_year_thread.first_post = previous_year_thread.last_post = previous_year_post
+        previous_year_thread.save()
+
+        previous_year_post.original = (
+            "This thread shows timestamps for content from another year."
+        )
+
+        previous_year_post.parsed = (
+            "<p>This thread shows timestamps for content from another year.</p>"
+        )
+
+        previous_year_post.search_document = previous_year_post.original
+
+        update_post_checksum(previous_year_post)
+        previous_year_post.update_search_vector()
+        previous_year_post.save()
+
+        current_year_timestamp = timestamp.replace(
+            month=randint(1, timestamp.month),
+            day=randint(1, 28),
+            hour=randint(0, 23),
+            minute=randint(0, 59),
+            second=randint(0, 59),
+        )
+
+        current_year_thread = Thread.objects.create(
+            category=first_category,
+            title="Thread with last activity from current year",
+            slug="thread-with-last-activity-from-current-year",
+            started_on=current_year_timestamp,
+            last_post_on=current_year_timestamp,
+            starter=None,
+            starter_name="Misago",
+            starter_slug="misago",
+            last_poster=None,
+            last_poster_name="Misago",
+            last_poster_slug="misago",
+        )
+        current_year_post = Post.objects.create(
+            category=first_category,
+            thread=current_year_thread,
+            poster=None,
+            poster_name="Misago",
+            posted_on=current_year_timestamp,
+            updated_on=current_year_timestamp,
+        )
+
+        current_year_thread.first_post = current_year_thread.last_post = current_year_post
+        current_year_thread.save()
+
+        current_year_post.original = (
+            "This thread shows timestamps for content from current year."
+        )
+
+        current_year_post.parsed = (
+            "<p>This thread shows timestamps for content from current year.</p>"
+        )
+
+        current_year_post.search_document = current_year_post.original
+
+        update_post_checksum(current_year_post)
+        current_year_post.update_search_vector()
+        current_year_post.save()
+
+        current_week_timestamp = timestamp.replace(
+            hour=randint(0, 23),
+            minute=randint(0, 59),
+            second=randint(0, 59),
+        ) - timedelta(days=3)
+
+        current_week_thread = Thread.objects.create(
+            category=first_category,
+            title="Thread with last activity from current week",
+            slug="thread-with-last-activity-from-current-week",
+            started_on=current_week_timestamp,
+            last_post_on=current_week_timestamp,
+            starter=None,
+            starter_name="Misago",
+            starter_slug="misago",
+            last_poster=None,
+            last_poster_name="Misago",
+            last_poster_slug="misago",
+        )
+        current_week_post = Post.objects.create(
+            category=first_category,
+            thread=current_week_thread,
+            poster=None,
+            poster_name="Misago",
+            posted_on=current_week_timestamp,
+            updated_on=current_week_timestamp,
+        )
+
+        current_week_thread.first_post = current_week_thread.last_post = current_week_post
+        current_week_thread.save()
+
+        current_week_post.original = (
+            "This thread shows timestamps for content from current week."
+        )
+
+        current_week_post.parsed = (
+            "<p>This thread shows timestamps for content from current week.</p>"
+        )
+
+        current_week_post.search_document = current_week_post.original
+
+        update_post_checksum(current_week_post)
+        current_week_post.update_search_vector()
+        current_week_post.save()
+
+        yesterday_timestamp = timestamp.replace(
+            hour=randint(0, 15),
+            minute=randint(0, 59),
+            second=randint(0, 59),
+        ) - timedelta(days=1)
+
+        yesterday_thread = Thread.objects.create(
+            category=first_category,
+            title="Thread with last activity from yesterday",
+            slug="thread-with-last-activity-from-yesterday-week",
+            started_on=yesterday_timestamp,
+            last_post_on=yesterday_timestamp,
+            starter=None,
+            starter_name="Misago",
+            starter_slug="misago",
+            last_poster=None,
+            last_poster_name="Misago",
+            last_poster_slug="misago",
+        )
+        yesterday_post = Post.objects.create(
+            category=first_category,
+            thread=yesterday_thread,
+            poster=None,
+            poster_name="Misago",
+            posted_on=yesterday_timestamp,
+            updated_on=yesterday_timestamp,
+        )
+
+        yesterday_thread.first_post = yesterday_thread.last_post = yesterday_post
+        yesterday_thread.save()
+
+        yesterday_post.original = (
+            "This thread shows timestamps for content from yesterday."
+        )
+
+        yesterday_post.parsed = (
+            "<p>This thread shows timestamps for content from yesterday.</p>"
+        )
+
+        yesterday_post.search_document = yesterday_post.original
+
+        update_post_checksum(yesterday_post)
+        yesterday_post.update_search_vector()
+        yesterday_post.save()
+
         readme_thread = Thread.objects.create(
             category=first_category,
             title="Welcome to the Misago Dev Fixture! Read me first!",
@@ -316,8 +503,8 @@ class Command(BaseCommand):
         readme_post.update_search_vector()
         readme_post.save()
 
-        first_category.threads = models.F("threads") + 1
-        first_category.posts = models.F("posts") + 1
+        first_category.threads = models.F("threads") + 4
+        first_category.posts = models.F("posts") + 4
         first_category.set_last_thread(readme_thread)
         first_category.save()
 

--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -4,7 +4,6 @@ from textwrap import dedent
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
-from django.db import models
 from django.utils import timezone
 from misago.cache.enums import CacheName
 from misago.cache.versions import get_cache_versions, invalidate_cache
@@ -506,9 +505,7 @@ class Command(BaseCommand):
         readme_post.update_search_vector()
         readme_post.save()
 
-        first_category.threads = models.F("threads") + 4
-        first_category.posts = models.F("posts") + 4
-        first_category.set_last_thread(readme_thread)
+        first_category.synchronize()
         first_category.save()
 
         self.stdout.write(

--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -387,6 +387,7 @@ class Command(BaseCommand):
             This Misago site was pre-populated with some initial data to make starting development easier:
 
             - Example categories hierarchy
+            - Threads with activity from different times
             - Moderator account
             - Two regular user accounts
             - Banned user account
@@ -433,6 +434,7 @@ class Command(BaseCommand):
             "<p>This Misago site was pre-populated with some initial data to make starting development easier:</p>"
             "<ul>"
             "<li>Example categories hierarchy</li>"
+            "<li>Threads with activity from different times</li>"
             "<li>Moderator account</li>"
             "<li>Two regular user accounts</li>"
             "<li>Banned user account</li>"
@@ -472,6 +474,7 @@ class Command(BaseCommand):
         readme_post.search_document = (
             "This Misago site was pre-populated with some initial data to make starting development easier: "
             "- Example categories hierarchy "
+            "- Threads with activity from different times "
             "- Moderator account "
             "- Two regular user accounts "
             "- Banned user account "

--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -387,7 +387,7 @@ class Command(BaseCommand):
             This Misago site was pre-populated with some initial data to make starting development easier:
 
             - Example categories hierarchy
-            - Threads with activity from different times
+            - Threads with activity from different dates
             - Moderator account
             - Two regular user accounts
             - Banned user account
@@ -434,7 +434,7 @@ class Command(BaseCommand):
             "<p>This Misago site was pre-populated with some initial data to make starting development easier:</p>"
             "<ul>"
             "<li>Example categories hierarchy</li>"
-            "<li>Threads with activity from different times</li>"
+            "<li>Threads with activity from different dates</li>"
             "<li>Moderator account</li>"
             "<li>Two regular user accounts</li>"
             "<li>Banned user account</li>"
@@ -474,7 +474,7 @@ class Command(BaseCommand):
         readme_post.search_document = (
             "This Misago site was pre-populated with some initial data to make starting development easier: "
             "- Example categories hierarchy "
-            "- Threads with activity from different times "
+            "- Threads with activity from different dates "
             "- Moderator account "
             "- Two regular user accounts "
             "- Banned user account "

--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -202,7 +202,9 @@ class Command(BaseCommand):
             updated_on=previous_year_timestamp,
         )
 
-        previous_year_thread.first_post = previous_year_thread.last_post = previous_year_post
+        previous_year_thread.first_post = previous_year_thread.last_post = (
+            previous_year_post
+        )
         previous_year_thread.save()
 
         previous_year_post.original = (
@@ -249,7 +251,9 @@ class Command(BaseCommand):
             updated_on=current_year_timestamp,
         )
 
-        current_year_thread.first_post = current_year_thread.last_post = current_year_post
+        current_year_thread.first_post = current_year_thread.last_post = (
+            current_year_post
+        )
         current_year_thread.save()
 
         current_year_post.original = (
@@ -294,7 +298,9 @@ class Command(BaseCommand):
             updated_on=current_week_timestamp,
         )
 
-        current_week_thread.first_post = current_week_thread.last_post = current_week_post
+        current_week_thread.first_post = current_week_thread.last_post = (
+            current_week_post
+        )
         current_week_thread.save()
 
         current_week_post.original = (


### PR DESCRIPTION
Adds extra threads to dev fixture demonstrating different timestamp types:

<img width="91" alt="Zrzut ekranu 2024-08-9 o 23 22 26" src="https://github.com/user-attachments/assets/20d84a01-8402-48d7-b504-97e0db6bb793">

Relates to #1786