### PR TITLE
update path to search component in frontend

### DIFF
--- a/frontend/src/components/Navbar/NavbarSearchDropdown.jsx
+++ b/frontend/src/components/Navbar/NavbarSearchDropdown.jsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Dropdown } from "../Dropdown"
-import { SearchDropdown } from "../Search"
+import { SearchDropdown } from "../search"
 import NavbarSearchToggle from "./NavbarSearchToggle"
 
 export default function NavbarSearchDropdown({ id, className, url }) {

--- a/frontend/src/initializers/components/search-overlay.js
+++ b/frontend/src/initializers/components/search-overlay.js
@@ -1,7 +1,7 @@
 import React from "react"
 import ReactDOM from "react-dom"
 import { Provider } from "react-redux"
-import { SearchOverlay } from "../../components/Search"
+import { SearchOverlay } from "../../components/search"
 import store from "../../services/store"
 
 export default function initializer(context) {


### PR DESCRIPTION
I tried to run this locally, but it failed. The navbar, profile dropdown, sign-in/register buttons and search functions were not working.

I saw that the `navbar` and `search-overlay` components were referencing what looked to be a renamed `search` component directory.

After fixing the imports, the issue resolved itself.

@rafalp 