### PR TITLE
Mark private threads category as read improvements

### DIFF
--- a/misago/readtracker/privatethreads.py
+++ b/misago/readtracker/privatethreads.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django.http import HttpRequest
 from django.db.models import F, Q
 
@@ -9,13 +7,8 @@ from .readtime import get_default_read_time
 from .tracker import annotate_threads_read_time
 
 
-def are_private_threads_read(
-    request: HttpRequest, category: Category, category_read_time: datetime | None
-) -> bool:
+def are_private_threads_read(request: HttpRequest, category: Category) -> bool:
     read_time = get_default_read_time(request.settings, request.user)
-
-    if category_read_time:
-        read_time = max(read_time, category_read_time)
 
     queryset = (
         filter_private_threads_queryset(

--- a/misago/readtracker/tracker.py
+++ b/misago/readtracker/tracker.py
@@ -168,22 +168,20 @@ def mark_category_read(
     category: Category,
     *,
     force_update: bool = False,
-    read_time: datetime | None = None
 ):
     create_row = True
-    read_time = read_time or category.last_post_on
 
     if force_update or getattr(category, "read_time", None):
         create_row = not ReadCategory.objects.filter(
             user=user,
             category=category,
-        ).update(read_time=read_time)
+        ).update(read_time=category.last_post_on)
 
     if create_row:
         ReadCategory.objects.create(
             user=user,
             category=category,
-            read_time=read_time,
+            read_time=category.last_post_on,
         )
 
     ReadThread.objects.filter(user=user, category=category).delete()

--- a/misago/readtracker/tracker.py
+++ b/misago/readtracker/tracker.py
@@ -163,20 +163,27 @@ def mark_thread_read(user: "User", thread: Thread, read_time: datetime):
         )
 
 
-def mark_category_read(user: "User", category: Category, *, force_update: bool = False):
+def mark_category_read(
+    user: "User",
+    category: Category,
+    *,
+    force_update: bool = False,
+    read_time: datetime | None = None
+):
     create_row = True
+    read_time = read_time or category.last_post_on
 
     if force_update or getattr(category, "read_time", None):
         create_row = not ReadCategory.objects.filter(
             user=user,
             category=category,
-        ).update(read_time=category.last_post_on)
+        ).update(read_time=read_time)
 
     if create_row:
         ReadCategory.objects.create(
             user=user,
             category=category,
-            read_time=category.last_post_on,
+            read_time=read_time,
         )
 
     ReadThread.objects.filter(user=user, category=category).delete()

--- a/misago/threads/views/list.py
+++ b/misago/threads/views/list.py
@@ -1375,10 +1375,13 @@ class PrivateThreadsListView(ListView):
             thread_data.update(self.get_thread_urls(thread))
             items.append(thread_data)
 
-        if mark_read and are_private_threads_read(
-            request, category, category.read_time
+        if (
+            mark_read
+            and request.user.is_authenticated
+            and request.user.unread_private_threads
+            and are_private_threads_read(request, category, category.read_time)
         ):
-            mark_category_read(request.user, category)
+            mark_category_read(request.user, category, read_time=timezone.now())
             request.user.clear_unread_private_threads()
 
         return {

--- a/misago/threads/views/list.py
+++ b/misago/threads/views/list.py
@@ -1379,7 +1379,7 @@ class PrivateThreadsListView(ListView):
             mark_read
             and request.user.is_authenticated
             and request.user.unread_private_threads
-            and are_private_threads_read(request, category, category.read_time)
+            and are_private_threads_read(request, category)
         ):
             request.user.clear_unread_private_threads()
 

--- a/misago/threads/views/list.py
+++ b/misago/threads/views/list.py
@@ -1381,7 +1381,6 @@ class PrivateThreadsListView(ListView):
             and request.user.unread_private_threads
             and are_private_threads_read(request, category, category.read_time)
         ):
-            mark_category_read(request.user, category, read_time=timezone.now())
             request.user.clear_unread_private_threads()
 
         return {

--- a/misago/threads/views/replies.py
+++ b/misago/threads/views/replies.py
@@ -328,7 +328,7 @@ class PrivateThreadRepliesView(RepliesView, PrivateThreadView):
         category: Category,
         category_read_time: datetime | None,
     ) -> bool:
-        return are_private_threads_read(request, category, category_read_time)
+        return are_private_threads_read(request, category)
 
     def mark_category_read(
         self,

--- a/misago/threads/views/replies.py
+++ b/misago/threads/views/replies.py
@@ -204,13 +204,11 @@ class RepliesView(View):
         category: Category,
         *,
         force_update: bool = False,
-        read_time: datetime | None = None,
     ):
         mark_category_read(
             user,
             category,
             force_update=force_update,
-            read_time=read_time,
         )
 
     def read_user_notifications(self, user: "User", posts: list[Post]):
@@ -338,15 +336,7 @@ class PrivateThreadRepliesView(RepliesView, PrivateThreadView):
         category: Category,
         *,
         force_update: bool = False,
-        read_time: datetime | None = None,
     ):
-        super().mark_category_read(
-            user,
-            category,
-            force_update=force_update,
-            read_time=timezone.now(),
-        )
-
         user.clear_unread_private_threads()
 
 

--- a/misago/threads/views/replies.py
+++ b/misago/threads/views/replies.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import QuerySet, prefetch_related_objects
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
+from django.utils import timezone
 from django.views import View
 
 from ...categories.models import Category
@@ -202,9 +203,15 @@ class RepliesView(View):
         user: "User",
         category: Category,
         *,
-        force_update: bool,
+        force_update: bool = False,
+        read_time: datetime | None = None,
     ):
-        mark_category_read(user, category, force_update=force_update)
+        mark_category_read(
+            user,
+            category,
+            force_update=force_update,
+            read_time=read_time,
+        )
 
     def read_user_notifications(self, user: "User", posts: list[Post]):
         updated_notifications = user.notification_set.filter(
@@ -330,9 +337,15 @@ class PrivateThreadRepliesView(RepliesView, PrivateThreadView):
         user: "User",
         category: Category,
         *,
-        force_update: bool,
+        force_update: bool = False,
+        read_time: datetime | None = None,
     ):
-        super().mark_category_read(user, category, force_update=force_update)
+        super().mark_category_read(
+            user,
+            category,
+            force_update=force_update,
+            read_time=timezone.now(),
+        )
 
         user.clear_unread_private_threads()
 


### PR DESCRIPTION
Updates `mark_category_read` calls for private threads category to don't call `mark_category_read` because it doesn't make sense for those. 

Fixes #1803