### PR TITLE
Replace category signals with functions

### DIFF
--- a/misago/categories/content.py
+++ b/misago/categories/content.py
@@ -1,0 +1,9 @@
+from .models import Category
+
+
+def move_category_content(src: Category, dst: Category):
+    _move_category_content_action(src, dst)
+
+
+def _move_category_content_action(src: Category, dst: Category):
+    pass

--- a/misago/categories/content.py
+++ b/misago/categories/content.py
@@ -6,4 +6,14 @@ def move_category_content(src: Category, dst: Category):
 
 
 def _move_category_content_action(src: Category, dst: Category):
+    src.readthreadset.update(category=dst)
+    src.threadset.update(category=dst)
+    src.postset.update(category=dst)
+
+
+def delete_category_content(category: Category):
+    _delete_category_content_action(category)
+
+
+def _delete_category_content_action(category: Category):
     pass

--- a/misago/categories/delete.py
+++ b/misago/categories/delete.py
@@ -1,5 +1,10 @@
+from ..postgres.delete import delete_many, delete_one
 from .models import Category
 
 
 def delete_category(category: Category):
-    category.delete()
+    _delete_category_action(category)
+
+
+def _delete_category_action(category: Category):
+    delete_one(category)

--- a/misago/categories/management/commands/healcategorytrees.py
+++ b/misago/categories/management/commands/healcategorytrees.py
@@ -9,7 +9,7 @@ from ...mptt import heal_category_trees
 class Command(BaseCommand):
     """
     This command rebuilds the category trees in the database.
-    
+
     It's useful when the MPTT data of one or more categories becomes invalid,
     either due to a bug or manual database manipulation.
     """

--- a/misago/categories/synchronization.py
+++ b/misago/categories/synchronization.py
@@ -1,0 +1,9 @@
+from .models import Category
+
+
+def synchronize_category(category: Category):
+    _synchronize_category_action(category)
+
+
+def _synchronize_category_action(category: Category):
+    pass

--- a/misago/permissions/copy.py
+++ b/misago/permissions/copy.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest
 
 from ..categories.models import Category
-from ..postgres.delete import delete_all
+from ..postgres.delete import delete_many
 from ..users.models import Group
 from .hooks import copy_category_permissions_hook, copy_group_permissions_hook
 from .models import CategoryGroupPermission
@@ -22,7 +22,7 @@ def _copy_category_permissions_action(
     dst: Category,
     request: HttpRequest | None = None,
 ) -> None:
-    delete_all(CategoryGroupPermission, category_id=dst.id)
+    delete_many(CategoryGroupPermission, category_id=dst.id)
 
     queryset = CategoryGroupPermission.objects.filter(category=src).values_list(
         "group_id", "permission"
@@ -76,7 +76,7 @@ def _copy_group_permissions_action(
 
 
 def _copy_group_category_permissions(src: Group, dst: Group) -> None:
-    delete_all(CategoryGroupPermission, group_id=dst.id)
+    delete_many(CategoryGroupPermission, group_id=dst.id)
 
     queryset = CategoryGroupPermission.objects.filter(group=src).values_list(
         "category_id", "permission"

--- a/misago/postgres/delete.py
+++ b/misago/postgres/delete.py
@@ -16,19 +16,19 @@ def delete_one(obj: Model) -> int:
     return execute_rowcount(f'DELETE FROM "{table}" WHERE "{pkey}" = %s;', [obj.pk])
 
 
-def delete_all(model: Type[Model], **where):
+def delete_many(model: Type[Model], **where):
     """Deletes multiple rows from the database, bypassing all Django ORM logic.
 
     Requires at least ONE kwarg with a name of model field to use in the delete:
 
-    `delete_all(User, group_id=9)` executes the
+    `delete_many(User, group_id=9)` executes the
     `DELETE FROM "misago_users_user" WHERE "group_id" = 9;` query.
-    `delete_all(User, pk=[1, 3, 4])` executes the
+    `delete_many(User, pk=[1, 3, 4])` executes the
     `DELETE FROM "misago_users_user" WHERE "id" IN (1, 3, 4);` query.
 
     Multiple kwargs are joined with the "AND" keyword:
 
-    `delete_all(User, group_id=9, is_misago_admin=False)` will execute the
+    `delete_many(User, group_id=9, is_misago_admin=False)` will execute the
     `DELETE FROM "misago_users_user" WHERE "group_id" = 9 AND "is_misago_admin" = FALSE;`
     query.
 

--- a/misago/postgres/tests/test_delete.py
+++ b/misago/postgres/tests/test_delete.py
@@ -2,7 +2,7 @@ import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
 from ...cache.models import CacheVersion
-from ..delete import delete_all, delete_one
+from ..delete import delete_many, delete_one
 
 
 def test_one_object_is_deleted_from_database(db):
@@ -30,7 +30,7 @@ def test_multiple_objects_are_deleted_from_database_using_column_equals(db):
     cache_version_2 = CacheVersion.objects.create(cache="test_2", version="test")
     cache_version_3 = CacheVersion.objects.create(cache="test_3", version="other")
 
-    result = delete_all(CacheVersion, version="test")
+    result = delete_many(CacheVersion, version="test")
     assert result == 2
 
     with pytest.raises(ObjectDoesNotExist):
@@ -46,7 +46,7 @@ def test_multiple_objects_are_deleted_from_database_using_column_in(db):
     cache_version_2 = CacheVersion.objects.create(cache="test_2", version="test")
     cache_version_3 = CacheVersion.objects.create(cache="test_3", version="other")
 
-    result = delete_all(CacheVersion, cache=["test_1", "test_2"])
+    result = delete_many(CacheVersion, cache=["test_1", "test_2"])
     assert result == 2
 
     with pytest.raises(ObjectDoesNotExist):
@@ -62,7 +62,7 @@ def test_multiple_objects_are_deleted_from_database_using_column_and_column(db):
     cache_version_2 = CacheVersion.objects.create(cache="test_2", version="test")
     cache_version_3 = CacheVersion.objects.create(cache="test_3", version="other")
 
-    result = delete_all(CacheVersion, cache=["test_1", "test_2"], version="delete")
+    result = delete_many(CacheVersion, cache=["test_1", "test_2"], version="delete")
     assert result == 1
 
     with pytest.raises(ObjectDoesNotExist):
@@ -72,13 +72,13 @@ def test_multiple_objects_are_deleted_from_database_using_column_and_column(db):
     cache_version_3.refresh_from_db()
 
 
-def test_delete_all_raises_value_error_if_where_clause_is_not_set(db):
+def test_delete_many_raises_value_error_if_where_clause_is_not_set(db):
     cache_version_1 = CacheVersion.objects.create(cache="test_1", version="delete")
     cache_version_2 = CacheVersion.objects.create(cache="test_2", version="test")
     cache_version_3 = CacheVersion.objects.create(cache="test_3", version="other")
 
     with pytest.raises(ValueError):
-        delete_all(CacheVersion)
+        delete_many(CacheVersion)
 
     # No rows have been deleted
     cache_version_1.refresh_from_db()

--- a/misago/users/groups.py
+++ b/misago/users/groups.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest
 
 from ..core.utils import slugify
 from ..permissions.models import CategoryGroupPermission, Moderator
-from ..postgres.delete import delete_all, delete_one
+from ..postgres.delete import delete_many, delete_one
 from ..postgres.execute import execute_fetch_all
 from .hooks import (
     create_group_hook,
@@ -147,9 +147,9 @@ def delete_group(group: Group, request: HttpRequest | None = None):
 
 
 def _delete_group_action(group: Group, request: HttpRequest | None = None):
-    delete_all(CategoryGroupPermission, group_id=group.id)
-    delete_all(Moderator, group_id=group.id)
-    delete_all(GroupDescription, group_id=group.id)
+    delete_many(CategoryGroupPermission, group_id=group.id)
+    delete_many(Moderator, group_id=group.id)
+    delete_many(GroupDescription, group_id=group.id)
     delete_one(group)
 
     remove_group_from_users_groups_ids.delay(group.id)

--- a/misago/users/hooks/create_group.py
+++ b/misago/users/hooks/create_group.py
@@ -98,7 +98,6 @@ class CreateGroupHook(FilterHook[CreateGroupHookAction, CreateGroupHookFilter]):
 
     ```python
     from django.http import HttpRequest
-    from misago.postgres.delete import delete_all
     from misago.users.models import Group
 
     @create_group_hook.append_filter

--- a/misago/users/hooks/delete_group.py
+++ b/misago/users/hooks/delete_group.py
@@ -77,7 +77,7 @@ class DeleteGroupHook(FilterHook[DeleteGroupHookAction, DeleteGroupHookFilter]):
 
     ```python
     from django.http import HttpRequest
-    from misago.postgres.delete import delete_all
+    from misago.postgres.delete import delete_many
     from misago.users.models import Group
 
     from .models import GroupPromotionRule
@@ -87,7 +87,7 @@ class DeleteGroupHook(FilterHook[DeleteGroupHookAction, DeleteGroupHookFilter]):
         action, group: Group, request: HttpRequest | None = None
     ) -> None:
         # Delete promotion rules related with this group bypassing the Django ORM
-        delete_all(GroupPromotionRule, group_id=group.id)
+        delete_many(GroupPromotionRule, group_id=group.id)
 
         # Call the next function in chain
         return action(group, request)


### PR DESCRIPTION
Fixes #1801

# TODO

- [ ] Move category content to the other category
- [ ] Delete category content
- [ ] Bulk delete categories content
- [ ] Delete category
- [ ] Bulk delete categories
- [ ] Synchronize category
- [ ] Update admin to use new functions
- [ ] Regenerate hooks reference

# Related models

- `Attachment`
  - [ ] move
  - [ ] delete
- `RoleCategoryACL`
  - [ ] delete
- `Notification`
  - [ ] move
  - [ ] delete
- `WatchedThread`
  - [ ] move
  - [ ] delete
- `CategoryGroupPermission`
  - [ ] delete
- `ReadCategory`
  - [ ] delete
- `ReadThread`
  - [ ] move
  - [ ] delete
- `Post`
  - [ ] move
  - [ ] delete
- `PostEdit`
  - [ ] move
  - [ ] delete
- `PostLike`
  - [ ] move
  - [ ] delete
- `Thread`
  - [ ] move
  - [ ] delete
- `Subscription`
  - [ ] move
  - [ ] delete
- `Poll`
  - [ ] move
  - [ ] delete
- `PollVote`
  - [ ] move
  - [ ] delete