### PR TITLE
Add nodes validation to the admin site

### DIFF
--- a/misago/admin/tests/test_admin_site.py
+++ b/misago/admin/tests/test_admin_site.py
@@ -1,25 +1,108 @@
-from ..site import Node
+import pytest
+
+from ..site import AdminSite, AdminSiteInvalidNodeError, Node
+
+
+def test_admin_site_validate_nodes_raises_error_if_node_has_invalid_parent():
+    site = AdminSite()
+
+    site.add_node(
+        name="Test",
+        icon="test",
+        namespace="test",
+        parent="invalid",
+    )
+
+    with pytest.raises(AdminSiteInvalidNodeError) as exc_info:
+        site.validate_nodes()
+
+    assert str(exc_info.value) == (
+        "Misago Admin node 'misago:admin:invalid:test:index' has "
+        "an invalid parent 'misago:admin:invalid'."
+    )
+
+
+def test_admin_site_validate_nodes_raises_error_if_node_has_invalid_after():
+    site = AdminSite()
+
+    site.add_node(
+        name="Test",
+        icon="test",
+        namespace="parent",
+    )
+    site.add_node(
+        name="Test",
+        icon="test",
+        parent="parent",
+        namespace="second",
+        after="invalid",
+    )
+    site.add_node(
+        name="Test",
+        icon="test",
+        parent="parent",
+        namespace="first",
+    )
+
+    with pytest.raises(AdminSiteInvalidNodeError) as exc_info:
+        site.validate_nodes()
+
+    assert str(exc_info.value) == (
+        "Misago Admin node 'misago:admin:parent:second:index' has "
+        "an invalid after node 'misago:admin:parent:invalid'."
+    )
+
+
+def test_admin_site_validate_nodes_raises_error_if_node_has_invalid_before():
+    site = AdminSite()
+
+    site.add_node(
+        name="Test",
+        icon="test",
+        namespace="parent",
+    )
+    site.add_node(
+        name="Test",
+        icon="test",
+        parent="parent",
+        namespace="second",
+        before="invalid",
+    )
+    site.add_node(
+        name="Test",
+        icon="test",
+        parent="parent",
+        namespace="first",
+    )
+
+    with pytest.raises(AdminSiteInvalidNodeError) as exc_info:
+        site.validate_nodes()
+
+    assert str(exc_info.value) == (
+        "Misago Admin node 'misago:admin:parent:second:index' has "
+        "an invalid before node 'misago:admin:parent:invalid'."
+    )
 
 
 def test_node_is_added_at_end_of_parent_children():
-    master = Node(name="Apples", link="misago:index")
+    parent = Node(name="Apples", link="misago:index")
     child = Node(name="Oranges", link="misago:index")
-    master.add_node(child)
+    parent.add_node(child)
 
-    assert master.children()[-1].name == child.name
+    assert parent.children()[-1].name == child.name
 
 
 def test_add_node_after():
     """add_node added node after specific node"""
-    master = Node(name="Apples", link="misago:index")
+    parent = Node(name="Apples", link="misago:index")
 
     child = Node(name="Oranges", link="misago:index")
-    master.add_node(child)
+    parent.add_node(child)
 
     test = Node(name="Potatoes", link="misago:index")
-    master.add_node(test, after="misago:index")
+    parent.add_node(test, after="misago:index")
 
-    all_nodes = master.children()
+    all_nodes = parent.children()
     for i, node in enumerate(all_nodes):
         if node.name == test.name:
             assert all_nodes[i - 1].name == child.name
@@ -27,15 +110,15 @@ def test_add_node_after():
 
 def test_add_node_before():
     """add_node added node  before specific node"""
-    master = Node(name="Apples", link="misago:index")
+    parent = Node(name="Apples", link="misago:index")
 
     child = Node(name="Oranges", link="misago:index")
-    master.add_node(child)
+    parent.add_node(child)
 
     test = Node(name="Potatoes", link="misago:index")
-    master.add_node(test, before="misago:index")
+    parent.add_node(test, before="misago:index")
 
-    all_nodes = master.children()
+    all_nodes = parent.children()
     for i, node in enumerate(all_nodes):
         if node.name == test.name:
             assert all_nodes[i + 1].name == child.name

--- a/misago/categories/management/commands/healcategorytrees.py
+++ b/misago/categories/management/commands/healcategorytrees.py
@@ -9,7 +9,7 @@ from ...mptt import heal_category_trees
 class Command(BaseCommand):
     """
     This command rebuilds the category trees in the database.
-    
+
     It's useful when the MPTT data of one or more categories becomes invalid,
     either due to a bug or manual database manipulation.
     """


### PR DESCRIPTION
This PR adds admin nodes validation to the `AdminSite` class. This validation produces much more descriptive error messages when nodes tree has errors:

<img width="1005" alt="Zrzut ekranu 2024-09-24 o 21 16 05" src="https://github.com/user-attachments/assets/86846480-b2ba-4b15-adb9-b67ed5c94740">

Fixes #1817