### PR TITLE
Add top and bottom toolbar variables to templates

### DIFF
--- a/misago/templates/misago/category/partial.html
+++ b/misago/templates/misago/category/partial.html
@@ -3,7 +3,7 @@
 {% endif %}
 
 <div id="misago-htmx-root">
-  {% include "misago/threads/toolbar.html" %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=True bottom_toolbar=False %}
 
   <ul class="threads-list" itemscope itemtype="http://schema.org/ItemList">
     <meta itemprop="itemListOrder" content="http://schema.org/ItemListOrderDescending">
@@ -17,7 +17,7 @@
     {% endif %}
   </ul>
 
-  {% include "misago/threads/toolbar.html" with bottom=True %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=False bottom_toolbar=True %}
 
   {% if threads.moderation_actions %}
     {% include "misago/threads/moderation_form.html" with moderation_actions=threads.moderation_actions %}

--- a/misago/templates/misago/private_thread/partial.html
+++ b/misago/templates/misago/private_thread/partial.html
@@ -4,7 +4,7 @@
 <title>{{ thread }}{% if feed.paginator.number > 1 %} | {% blocktrans with page=feed.paginator.number context "thread page title" %}Page {{ page }}{% endblocktrans %}{% endif %} | {% trans "Private threads" context "private threads page" %} | {{ settings.forum_name }}</title>
 {% endif %}
 <div id="misago-htmx-root">
-  {% include "misago/thread/toolbar.html" with bottom=False %}
+  {% include "misago/thread/toolbar.html" with top_toolbar=True bottom_toolbar=False %}
   {% includecomponent feed %}
-  {% include "misago/thread/toolbar.html" with bottom=True %}
+  {% include "misago/thread/toolbar.html" with top_toolbar=False bottom_toolbar=True %}
 </div>

--- a/misago/templates/misago/private_thread/toolbar.html
+++ b/misago/templates/misago/private_thread/toolbar.html
@@ -1,6 +1,6 @@
 {% load i18n misago_plugins %}
 
-<div class="toolbar">
+<div class="toolbar{% if top_toolbar %} toolbar-min-height{% endif %}">
   {% pluginoutlet PRIVATE_THREAD_REPLIES_PAGE_TOOLBAR_START %}
   {% if feed.paginator.has_other_pages %}
     <div class="toolbar-section{% if not bottom %} flex-order-last-xs{% endif %}">
@@ -12,18 +12,14 @@
   {% pluginoutlet PRIVATE_THREAD_REPLIES_PAGE_TOOLBAR_BEFORE_SPACER %}
   <div class="toolbar-spacer"></div>
   {% pluginoutlet PRIVATE_THREAD_REPLIES_PAGE_TOOLBAR_AFTER_SPACER %}
-  <div class="toolbar-section">
-    <div class="toolbar-item">
-      {% if reply.url %}
+  {% if reply.url and top_toolbar %}
+    <div class="toolbar-section">
+      <div class="toolbar-item">
         <a href="{{ reply.url }}" class="btn btn-primary btn-block">
           {% trans "Post reply" context "thread replies toolbar" %}
         </a>
-      {% else %}
-        <button class="btn btn-primary btn-block" disabled>
-          {% trans "Post reply" context "thread replies toolbar" %}
-        </button>
-      {% endif %}
+      </div>
     </div>
-  </div>
+  {% endif %}
   {% pluginoutlet PRIVATE_THREAD_REPLIES_PAGE_TOOLBAR_END %}
 </div>

--- a/misago/templates/misago/private_threads/partial.html
+++ b/misago/templates/misago/private_threads/partial.html
@@ -3,7 +3,7 @@
 {% endif %}
 
 <div id="misago-htmx-root">
-  {% include "misago/threads/toolbar.html" %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=True bottom_toolbar=False %}
 
   <ul class="threads-list" itemscope itemtype="http://schema.org/ItemList">
     {% if threads.enable_polling and not threads.paginator.has_previous %}
@@ -17,5 +17,5 @@
     {% endif %}
   </ul>
 
-  {% include "misago/threads/toolbar.html" with bottom=True %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=False bottom_toolbar=True %}
 </div>

--- a/misago/templates/misago/threads/partial.html
+++ b/misago/templates/misago/threads/partial.html
@@ -3,7 +3,7 @@
 {% endif %}
 
 <div id="misago-htmx-root">
-  {% include "misago/threads/toolbar.html" %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=True bottom_toolbar=False %}
 
   <ul class="threads-list" itemscope itemtype="http://schema.org/ItemList">
     <meta itemprop="itemListOrder" content="http://schema.org/ItemListOrderDescending">
@@ -17,7 +17,7 @@
     {% endif %}
   </ul>
 
-  {% include "misago/threads/toolbar.html" with bottom=True %}
+  {% include "misago/threads/toolbar.html" with top_toolbar=False bottom_toolbar=True %}
 
   {% if threads.moderation_actions %}
     {% include "misago/threads/moderation_form.html" with moderation_actions=threads.moderation_actions %}

--- a/misago/templates/misago/threads/toolbar.html
+++ b/misago/templates/misago/threads/toolbar.html
@@ -3,20 +3,20 @@
 <div class="toolbar">
   {% pluginoutlet THREADS_LIST_TOOLBAR_START %}
   {% if threads.paginator.has_previous or threads.paginator.has_next %}
-    <div class="toolbar-section{% if not bottom %} flex-order-last-xs{% endif %}">
+    <div class="toolbar-section{% if top_toolbar %} flex-order-last-xs{% endif %}">
       <div class="toolbar-item">
-        {% include "misago/threads/paginator.html" with bottom=bottom %}
+        {% include "misago/threads/paginator.html" with bottom=bottom_toolbar %}
       </div>
     </div>
   {% endif %}
-  {% if subcategories and not subcategories.template_name and not bottom %}
+  {% if subcategories and not subcategories.template_name and top_toolbar %}
     <div class="toolbar-section">
       <div class="toolbar-item">
         {% include "misago/threads/subcategories_dropdown.html" with category=category subcategories=subcategories.categories %}
       </div>
     </div>
   {% endif %}
-  {% if threads.filters and not bottom %}
+  {% if threads.filters and top_toolbar %}
     <div class="toolbar-section">
       <div class="toolbar-item">
         {% include "misago/threads/filters_dropdown.html" with active_filter=threads.active_filter filters=threads.filters remove_filters_url=threads.remove_filters_url %}
@@ -26,7 +26,7 @@
   {% pluginoutlet THREADS_LIST_TOOLBAR_BEFORE_SPACER %}
   <div class="toolbar-spacer"></div>
   {% pluginoutlet THREADS_LIST_TOOLBAR_AFTER_SPACER %}
-  {% if bottom and user.is_authenticated and threads.items %}
+  {% if bottom_toolbar and user.is_authenticated and threads.items %}
     <div class="toolbar-section flex-order-last-xs">
       <div class="toolbar-item">
         <noscript>
@@ -49,7 +49,7 @@
     </div>
   {% endif %}
   {% if start_thread_url %}
-    <div class="toolbar-section{% if not bottom %} flex-order-first-xs{% endif %}">
+    <div class="toolbar-section{% if top_toolbar %} flex-order-first-xs{% endif %}">
       <div class="toolbar-item">
         {% if start_thread_modal %}
           <a


### PR DESCRIPTION
Adds `top_toolbar` and `bottom_toolbar` to toolbar templates used on threads pages.