### PR TITLE
Add title syntax to markdown's links and images

### DIFF
--- a/dev-docs/plugins/hooks/clean-displayed-url-hook.md
+++ b/dev-docs/plugins/hooks/clean-displayed-url-hook.md
@@ -1,0 +1,80 @@
+# `clean_displayed_url_hook`
+
+This hook wraps the standard function that Misago uses to clean URLs for display in HTML
+
+
+## Location
+
+This hook can be imported from `misago.parser.hooks`:
+
+```python
+from misago.parser.hooks import clean_displayed_url_hook
+```
+
+
+## Filter
+
+```python
+def custom_clean_displayed_url_filter(action: CleanDisplayedURLHookAction, url: str) -> str:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: CleanDisplayedURLHookAction`
+
+A standard Misago function used to clean URLs for display in HTML or the next filter function from another plugin.
+
+See the [action](#action) section for details.
+
+
+#### `url: str`
+
+A `str` with URL to be cleaned.
+
+
+### Return value
+
+A `str` with the cleaned URL.
+
+
+## Action
+
+```python
+def clean_displayed_url_action(url: str) -> str:
+    ...
+```
+
+A standard Misago function used to clean URLs for display in HTML or the next filter function from another plugin.
+
+
+### Arguments
+
+#### `url: str`
+
+A `str` with URL to be cleaned.
+
+
+### Return value
+
+A `str` with the cleaned URL.
+
+
+## Example
+
+The code below implements a custom filter function that disables cleaning for the Wikipedia URLS:
+
+```python
+from misago.parser.hooks import clean_displayed_url_hook
+
+
+@clean_displayed_url_hook.append_filter
+def clean_displayed_url(action, url: str) -> str:
+    if "wikipedia" in url:
+        return url
+
+    return action(url)
+```

--- a/dev-docs/plugins/hooks/create-parser-hook.md
+++ b/dev-docs/plugins/hooks/create-parser-hook.md
@@ -130,6 +130,7 @@ The code below implements a custom filter function that adds new block pattern t
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import create_parser_hook
 from misago.parser.parser import Parser
 
 from .patterns import PluginPattern

--- a/dev-docs/plugins/hooks/get-ast-metadata-users-queryset-hook.md
+++ b/dev-docs/plugins/hooks/get-ast-metadata-users-queryset-hook.md
@@ -89,6 +89,8 @@ The code below implements a custom filter function that updates the queryset to 
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import get_ast_metadata_users_queryset_hook
+
 
 @get_ast_metadata_users_queryset_hook.append_filter
 def get_ast_metadata_users_queryset_exclude_promotors(

--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -51,6 +51,7 @@ Hooks instances are importable from the following Python modules:
 
 `misago.parser.hooks` defines the following hooks:
 
+- [`clean_displayed_url_hook`](./clean-displayed-url-hook.md)
 - [`create_parser_hook`](./create-parser-hook.md)
 - [`get_ast_metadata_users_queryset_hook`](./get-ast-metadata-users-queryset-hook.md)
 - [`render_ast_node_to_html_hook`](./render-ast-node-to-html-hook.md)

--- a/dev-docs/plugins/hooks/render-ast-node-to-html-hook.md
+++ b/dev-docs/plugins/hooks/render-ast-node-to-html-hook.md
@@ -96,6 +96,7 @@ The code below implements a custom filter function that replaces Twitter media l
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import render_ast_node_to_html_hook
 
 
 @render_ast_node_to_html_hook.append_filter

--- a/dev-docs/plugins/hooks/render-ast-node-to-plaintext-hook.md
+++ b/dev-docs/plugins/hooks/render-ast-node-to-plaintext-hook.md
@@ -110,6 +110,7 @@ The code below implements a custom filter function that only inserts images alt 
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import render_ast_node_to_plaintext_hook
 
 
 @render_ast_node_to_plaintext_hook.append_filter

--- a/dev-docs/plugins/hooks/replace-rich-text-tokens-hook.md
+++ b/dev-docs/plugins/hooks/replace-rich-text-tokens-hook.md
@@ -83,6 +83,7 @@ The code below implements a custom filter function that replaces default spoiler
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import replace_rich_text_tokens_hook
 from misago.parser.html import SPOILER_SUMMARY
 
 

--- a/dev-docs/plugins/hooks/setup-parser-context-hook.md
+++ b/dev-docs/plugins/hooks/setup-parser-context-hook.md
@@ -71,6 +71,7 @@ The code below implements a custom filter function that adds extra data to `plug
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import setup_parser_context_hook
 
 
 @setup_parser_context_hook.append_filter

--- a/dev-docs/plugins/hooks/update-ast-metadata-from-node-hook.md
+++ b/dev-docs/plugins/hooks/update-ast-metadata-from-node-hook.md
@@ -86,6 +86,7 @@ The code below implements a custom filter function that populates `threads` entr
 
 ```python
 from django.urls import Resolver404, resolve
+from misago.parser.hooks import update_ast_metadata_from_node_hook
 from misago.parser.context import ParserContext
 
 

--- a/dev-docs/plugins/hooks/update-ast-metadata-hook.md
+++ b/dev-docs/plugins/hooks/update-ast-metadata-hook.md
@@ -98,6 +98,7 @@ The code below implements a custom filter function that sets `threads` entry in 
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import update_ast_metadata_hook
 from misago.threads.models import Thread
 
 

--- a/dev-docs/plugins/hooks/update-ast-metadata-users-hook.md
+++ b/dev-docs/plugins/hooks/update-ast-metadata-users-hook.md
@@ -73,6 +73,7 @@ The code below implements a custom filter function that removes users with extra
 
 ```python
 from misago.parser.context import ParserContext
+from misago.parser.hooks import update_ast_metadata_users_hook
 
 
 @update_ast_metadata_users_hook.append_filter

--- a/misago/parser/hooks/__init__.py
+++ b/misago/parser/hooks/__init__.py
@@ -1,3 +1,4 @@
+from .clean_displayed_url import clean_displayed_url_hook
 from .create_parser import create_parser_hook
 from .get_ast_metadata_users_queryset import get_ast_metadata_users_queryset_hook
 from .render_ast_node_to_html import render_ast_node_to_html_hook
@@ -9,6 +10,7 @@ from .update_ast_metadata_from_node import update_ast_metadata_from_node_hook
 from .update_ast_metadata_users import update_ast_metadata_users_hook
 
 __all__ = [
+    "clean_displayed_url_hook",
     "create_parser_hook",
     "get_ast_metadata_users_queryset_hook",
     "render_ast_node_to_html_hook",

--- a/misago/parser/hooks/clean_displayed_url.py
+++ b/misago/parser/hooks/clean_displayed_url.py
@@ -1,0 +1,81 @@
+from typing import TYPE_CHECKING, Protocol
+
+from ...plugins.hooks import FilterHook
+
+
+class CleanDisplayedURLHookAction(Protocol):
+    """
+    A standard Misago function used to clean URLs for display in HTML
+    or the next filter function from another plugin.
+
+    # Arguments
+
+    ## `url: str`
+
+    A `str` with URL to be cleaned.
+
+    # Return value
+
+    A `str` with the cleaned URL.
+    """
+
+    def __call__(self, url: str) -> str: ...
+
+
+class CleanDisplayedURLHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: CleanDisplayedURLHookAction`
+
+    A standard Misago function used to clean URLs for display in HTML
+    or the next filter function from another plugin.
+
+    See the [action](#action) section for details.
+
+    ## `url: str`
+
+    A `str` with URL to be cleaned.
+
+    # Return value
+
+    A `str` with the cleaned URL.
+    """
+
+    def __call__(self, action: CleanDisplayedURLHookAction, url: str) -> str: ...
+
+
+class CleanDisplayedURLHook(
+    FilterHook[CleanDisplayedURLHookAction, CleanDisplayedURLHookFilter]
+):
+    """
+    This hook wraps the standard function that Misago uses to clean URLs for
+    display in HTML
+
+    # Example
+
+    The code below implements a custom filter function that disables cleaning
+    for the Wikipedia URLS:
+
+    ```python
+    from misago.parser.hooks import clean_displayed_url_hook
+
+
+    @clean_displayed_url_hook.append_filter
+    def clean_displayed_url(action, url: str) -> str:
+        if "wikipedia" in url:
+            return url
+
+        return action(url)
+    ```
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(self, action: CleanDisplayedURLHookAction, url: str) -> str:
+        return super().__call__(action, url)
+
+
+clean_displayed_url_hook = CleanDisplayedURLHook()

--- a/misago/parser/hooks/create_parser.py
+++ b/misago/parser/hooks/create_parser.py
@@ -120,6 +120,7 @@ class CreateParserHook(FilterHook[CreateParserHookAction, CreateParserHookFilter
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import create_parser_hook
     from misago.parser.parser import Parser
 
     from .patterns import PluginPattern

--- a/misago/parser/hooks/get_ast_metadata_users_queryset.py
+++ b/misago/parser/hooks/get_ast_metadata_users_queryset.py
@@ -98,6 +98,8 @@ class GetAstMetadataUsersQuerysetHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import get_ast_metadata_users_queryset_hook
+
 
     @get_ast_metadata_users_queryset_hook.append_filter
     def get_ast_metadata_users_queryset_exclude_promotors(

--- a/misago/parser/hooks/render_ast_node_to_html.py
+++ b/misago/parser/hooks/render_ast_node_to_html.py
@@ -91,6 +91,7 @@ class RenderAstNodeToHtmlHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import render_ast_node_to_html_hook
 
 
     @render_ast_node_to_html_hook.append_filter

--- a/misago/parser/hooks/render_ast_node_to_plaintext.py
+++ b/misago/parser/hooks/render_ast_node_to_plaintext.py
@@ -101,6 +101,7 @@ class RenderAstNodeToPlainTextHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import render_ast_node_to_plaintext_hook
 
 
     @render_ast_node_to_plaintext_hook.append_filter

--- a/misago/parser/hooks/replace_rich_text_tokens.py
+++ b/misago/parser/hooks/replace_rich_text_tokens.py
@@ -77,6 +77,7 @@ class ReplaceRichTextTokensHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import replace_rich_text_tokens_hook
     from misago.parser.html import SPOILER_SUMMARY
 
 

--- a/misago/parser/hooks/setup_parser_context.py
+++ b/misago/parser/hooks/setup_parser_context.py
@@ -68,6 +68,7 @@ class SetupParserContextHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import setup_parser_context_hook
 
 
     @setup_parser_context_hook.append_filter

--- a/misago/parser/hooks/update_ast_metadata.py
+++ b/misago/parser/hooks/update_ast_metadata.py
@@ -102,6 +102,7 @@ class UpdateAstMetadataHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import update_ast_metadata_hook
     from misago.threads.models import Thread
 
 

--- a/misago/parser/hooks/update_ast_metadata_from_node.py
+++ b/misago/parser/hooks/update_ast_metadata_from_node.py
@@ -89,6 +89,7 @@ class UpdateAstMetadataFromNodeHook(
 
     ```python
     from django.urls import Resolver404, resolve
+    from misago.parser.hooks import update_ast_metadata_from_node_hook
     from misago.parser.context import ParserContext
 
 

--- a/misago/parser/hooks/update_ast_metadata_users.py
+++ b/misago/parser/hooks/update_ast_metadata_users.py
@@ -76,6 +76,7 @@ class UpdateAstMetadataUsersHook(
 
     ```python
     from misago.parser.context import ParserContext
+    from misago.parser.hooks import update_ast_metadata_users_hook
 
 
     @update_ast_metadata_users_hook.append_filter

--- a/misago/parser/html.py
+++ b/misago/parser/html.py
@@ -4,7 +4,11 @@ from ..core.utils import slugify
 from .context import ParserContext
 from .exceptions import AstError
 from .hooks import render_ast_node_to_html_hook
-from .urls import clean_href
+from .htmlelement import html_element
+from .urls import clean_displayed_url, clean_url
+
+URL_REL = "external nofollow noopener"
+URL_TARGET = "_blank"
 
 
 def render_ast_to_html(context: ParserContext, ast: list[dict], metadata: dict) -> str:
@@ -134,23 +138,45 @@ def _render_ast_node_to_html_action(
         return f"<attachment={ast_node['name']}:{ast_node['slug']}:{ast_node['id']}>"
 
     if ast_type in ("image", "image-bbcode"):
-        src = escape(clean_href(ast_node["src"]))
-        alt = escape(ast_node["alt"]) if ast_node["alt"] else ""
-        return f'<img src="{src}" alt="{alt}" />'
+        return html_element(
+            "img",
+            attrs={
+                "src": clean_url(ast_node["src"]),
+                "alt": ast_node["alt"],
+                "title": ast_node.get("title"),
+            },
+        )
 
     if ast_type in ("url", "url-bbcode"):
         children = render_ast_to_html(context, ast_node["children"], metadata)
-        href = escape(clean_href(ast_node["href"]))
-        rel = "external nofollow noopener"
-        return f'<a href="{href}" rel="{rel}" target="_blank">{children or href}</a>'
+        href = clean_url(ast_node["href"])
+        return html_element(
+            "a",
+            children or clean_displayed_url(href),
+            {
+                "href": href,
+                "rel": URL_REL,
+                "target": URL_TARGET,
+                "title": ast_node.get("title") or href,
+            },
+        )
 
     if ast_type in ("auto-link", "auto-url"):
-        href = escape(clean_href(ast_node["href"]))
-        rel = "external nofollow noopener"
+        href = clean_url(ast_node["href"])
         if ast_node.get("image"):
-            return f'<img src="{href}" alt="" />'
+            return f'<img src="{escape(href)}" alt="" />'
         else:
-            return f'<a href="{href}" rel="{rel}" target="_blank">{href}</a>'
+            display_href = clean_displayed_url(href)
+            return html_element(
+                "a",
+                display_href,
+                {
+                    "href": href,
+                    "rel": URL_REL,
+                    "target": URL_TARGET,
+                    "title": href if len(href) - len(display_href) > 8 else None,
+                },
+            )
 
     if ast_type == "mention":
         username = slugify(ast_node["username"])

--- a/misago/parser/html.py
+++ b/misago/parser/html.py
@@ -142,7 +142,7 @@ def _render_ast_node_to_html_action(
             "img",
             attrs={
                 "src": clean_url(ast_node["src"]),
-                "alt": ast_node["alt"],
+                "alt": ast_node["alt"] or "",
                 "title": ast_node.get("title"),
             },
         )
@@ -150,14 +150,24 @@ def _render_ast_node_to_html_action(
     if ast_type in ("url", "url-bbcode"):
         children = render_ast_to_html(context, ast_node["children"], metadata)
         href = clean_url(ast_node["href"])
+        display_href = clean_displayed_url(href)
+        title = ast_node.get("title")
+
+        if title:
+            title = f"{title} ({href})"
+        elif not children:
+            title = None
+        elif display_href != clean_displayed_url(children):
+            title = href
+
         return html_element(
             "a",
-            children or clean_displayed_url(href),
+            children or display_href,
             {
                 "href": href,
                 "rel": URL_REL,
                 "target": URL_TARGET,
-                "title": ast_node.get("title") or href,
+                "title": title,
             },
         )
 

--- a/misago/parser/htmlelement.py
+++ b/misago/parser/htmlelement.py
@@ -22,6 +22,6 @@ def _html_attributes(attrs: dict) -> str:
     for attr, value in attrs.items():
         if value is True:
             html += " " + attr
-        elif value is not None and value != "":
+        elif value is not None:
             html += f' {attr}="{escape(value)}"'
     return html

--- a/misago/parser/htmlelement.py
+++ b/misago/parser/htmlelement.py
@@ -1,0 +1,27 @@
+from html import escape
+
+
+def html_element(
+    tag: str,
+    children: str | None = None,
+    attrs: dict | None = None,
+) -> str:
+    html = tag
+
+    if attrs:
+        html += _html_attributes(attrs)
+
+    if children is None:
+        return f"<{html} />"
+
+    return f"<{html}>{children}</{tag}>"
+
+
+def _html_attributes(attrs: dict) -> str:
+    html = ""
+    for attr, value in attrs.items():
+        if value is True:
+            html += " " + attr
+        elif value is not None and value != "":
+            html += f' {attr}="{escape(value)}"'
+    return html

--- a/misago/parser/patterns/urls.py
+++ b/misago/parser/patterns/urls.py
@@ -237,7 +237,9 @@ class UrlMarkdown(Pattern):
         return re.compile("|".join(f"({p})" for p in self.exclude_patterns))
 
 
-IMAGE_CONTENTS = re.compile(r"!(\[(?P<alt>(.|\n)*?)\])?\((?P<src>.*?)\)")
+IMAGE_CONTENTS = re.compile(
+    r"!(\[(?P<alt>(.|\n)*?)\])?\((?P<src>.*?)(?P<title>\s*\".*?\"\s*?)?\)"
+)
 
 
 class ImgMarkdown(Pattern):
@@ -252,11 +254,17 @@ class ImgMarkdown(Pattern):
         else:
             alt = None
 
+        if contents["title"]:
+            title = contents["title"].strip('" ') or None
+        else:
+            title = None
+
         src = contents["src"].strip()
         if URL_RE.match(src):
             return {
                 "type": "image",
                 "alt": alt,
+                "title": title,
                 "src": src,
             }
 

--- a/misago/parser/patterns/urls.py
+++ b/misago/parser/patterns/urls.py
@@ -172,7 +172,17 @@ class UrlMarkdown(Pattern):
 
             url, end = self.extract_url_from_source(url_source)
             if text and url:
-                ast.append(self.make_link_ast(parser, text, url, parents))
+                url, title = self.split_url_and_title(url)
+                ast.append(
+                    {
+                        "type": self.pattern_type,
+                        "href": url,
+                        "title": title or None,
+                        "children": parser.parse_inline(
+                            text, parents + [self.pattern_type]
+                        ),
+                    }
+                )
                 cursor = m.end() - 1 + end
             else:
                 markup = self.reverse_text_patterns(m.group(0), reserved_patterns)
@@ -223,14 +233,12 @@ class UrlMarkdown(Pattern):
         url = source[1:length].strip()
         return url, length + 1
 
-    def make_link_ast(
-        self, parser: Parser, text: str, url: str, parents: list[dict]
-    ) -> dict:
-        return {
-            "type": self.pattern_type,
-            "href": url,
-            "children": parser.parse_inline(text, parents + [self.pattern_type]),
-        }
+    def split_url_and_title(self, value: str) -> tuple[str | None, str | None]:
+        if ' "' not in value:
+            return value, None
+
+        url, title = [v.strip() for v in value.split('"', 1)]
+        return url or None, title.strip('" ') or None
 
     @cached_property
     def _exclude_patterns_re(self) -> re.Pattern:

--- a/misago/parser/plaintext.py
+++ b/misago/parser/plaintext.py
@@ -156,11 +156,14 @@ def _render_ast_node_to_plaintext_action(
         alt = ast_node["alt"] or ""
         title = ast_node.get("title") or ""
 
+        if title == alt:
+            title = ""
+
         if text_format == PlainTextFormat.META_DESCRIPTION:
             return title or alt
 
         src = clean_href(ast_node["src"])
-        return " ".join((title, alt, src))
+        return " ".join(i for i in (alt, src, title) if i).strip()
 
     if ast_type in ("url", "url-bbcode"):
         href = clean_href(ast_node["href"])

--- a/misago/parser/plaintext.py
+++ b/misago/parser/plaintext.py
@@ -154,27 +154,34 @@ def _render_ast_node_to_plaintext_action(
 
     if ast_type in ("image", "image-bbcode"):
         alt = ast_node["alt"] or ""
+        title = ast_node.get("title") or ""
+
         if text_format == PlainTextFormat.META_DESCRIPTION:
-            return alt
+            return title or alt
 
         src = clean_href(ast_node["src"])
-        return f"{alt} {src}".strip()
+        return " ".join((title, alt, src))
 
     if ast_type in ("url", "url-bbcode"):
         href = clean_href(ast_node["href"])
+        title = ast_node.get("title") or ""
 
         if children := render_inline_ast_to_plaintext(
             context, ast_node["children"], metadata, text_format
         ).strip():
             if text_format == PlainTextFormat.META_DESCRIPTION:
+                if title:
+                    return f"{children} ({title})"
                 return children
             else:
+                if title:
+                    return f"{children} ({title}) {href}"
                 return f"{children} {href}"
 
         if text_format == PlainTextFormat.META_DESCRIPTION:
-            return ""
+            return title
 
-        return href
+        return f"{title} {href}".strip()
 
     if ast_type == "attachment-group":
         return render_ast_to_plaintext(

--- a/misago/parser/plaintext.py
+++ b/misago/parser/plaintext.py
@@ -5,7 +5,7 @@ from .context import ParserContext
 from .enums import PlainTextFormat
 from .exceptions import AstError
 from .hooks import render_ast_node_to_plaintext_hook
-from .urls import clean_href
+from .urls import clean_url
 
 
 def render_ast_to_plaintext(
@@ -162,11 +162,11 @@ def _render_ast_node_to_plaintext_action(
         if text_format == PlainTextFormat.META_DESCRIPTION:
             return f"{alt} {title}".strip()
 
-        src = clean_href(ast_node["src"])
+        src = clean_url(ast_node["src"])
         return " ".join(i for i in (alt, src, title) if i).strip()
 
     if ast_type in ("url", "url-bbcode"):
-        href = clean_href(ast_node["href"])
+        href = clean_url(ast_node["href"])
         title = ast_node.get("title") or ""
 
         if children := render_inline_ast_to_plaintext(
@@ -198,7 +198,7 @@ def _render_ast_node_to_plaintext_action(
         if text_format == PlainTextFormat.META_DESCRIPTION:
             return ""
 
-        return clean_href(ast_node["href"])
+        return clean_url(ast_node["href"])
 
     if ast_type == "mention":
         username = slugify(ast_node["username"])

--- a/misago/parser/plaintext.py
+++ b/misago/parser/plaintext.py
@@ -160,7 +160,7 @@ def _render_ast_node_to_plaintext_action(
             title = ""
 
         if text_format == PlainTextFormat.META_DESCRIPTION:
-            return title or alt
+            return f"{alt} {title}".strip()
 
         src = clean_href(ast_node["src"])
         return " ".join(i for i in (alt, src, title) if i).strip()

--- a/misago/parser/tests/__snapshots__/test_html.ambr
+++ b/misago/parser/tests/__snapshots__/test_html.ambr
@@ -3,10 +3,10 @@
   '<p>See the site: </p><div class="rich-text-attachment-group"><attachment=image.png:image-png:123></div>'
 # ---
 # name: test_render_ast_to_html_auto_link
-  '<p>See the file: <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">https://misago-project.org</a></p>'
+  '<p>See the file: <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">misago-project.org</a></p>'
 # ---
 # name: test_render_ast_to_html_auto_url
-  '<p>See the site: <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">https://misago-project.org</a></p>'
+  '<p>See the site: <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">misago-project.org</a></p>'
 # ---
 # name: test_render_ast_to_html_bold_bbcode_text
   '<p>Hello <b>world</b>!</p>'
@@ -169,11 +169,11 @@
   '<ul><li>Lorem</li><li><em>Ipsum</em><ul><li>Met</li><li>Elit</li></ul></li><li>Dolor</li></ul>'
 # ---
 # name: test_render_ast_to_html_url
-  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank"><em>the site</em></a>!</p>'
+  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank" title="https://misago-project.org"><em>the site</em></a>!</p>'
 # ---
 # name: test_render_ast_to_html_url_bbcode
-  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">https://misago-project.org</a>!</p>'
+  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank">misago-project.org</a>!</p>'
 # ---
 # name: test_render_ast_to_html_url_bbcode_with_text
-  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank"><em>the site</em></a>!</p>'
+  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank" title="https://misago-project.org"><em>the site</em></a>!</p>'
 # ---

--- a/misago/parser/tests/__snapshots__/test_html.ambr
+++ b/misago/parser/tests/__snapshots__/test_html.ambr
@@ -93,6 +93,12 @@
 # name: test_render_ast_to_html_image_with_alt_text
   '<p>See the logo: <img src="https://misago-project.org/img.png" alt="Alt text" /></p>'
 # ---
+# name: test_render_ast_to_html_image_with_title
+  '<p>See the logo: <img src="https://misago-project.org/img.png" alt="" title="Amazing, right?" /></p>'
+# ---
+# name: test_render_ast_to_html_image_with_title_and_alt_text
+  '<p>See the logo: <img src="https://misago-project.org/img.png" alt="Alt text" title="Amazing, right?" /></p>'
+# ---
 # name: test_render_ast_to_html_inline_code
   '<p>Hello <code>world</code>!</p>'
 # ---
@@ -176,4 +182,7 @@
 # ---
 # name: test_render_ast_to_html_url_bbcode_with_text
   '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank" title="https://misago-project.org"><em>the site</em></a>!</p>'
+# ---
+# name: test_render_ast_to_plaintext_url_with_title
+  '<p>See <a href="https://misago-project.org" rel="external nofollow noopener" target="_blank" title="misago forums (https://misago-project.org)"><em>the site</em></a>!</p>'
 # ---

--- a/misago/parser/tests/__snapshots__/test_plaintext.ambr
+++ b/misago/parser/tests/__snapshots__/test_plaintext.ambr
@@ -95,6 +95,15 @@
 # name: test_render_ast_to_plaintext_image_with_title
   'See the logo: https://misago-project.org/img.png Amazing, right?'
 # ---
+# name: test_render_ast_to_plaintext_image_with_title_and_alt_text
+  'See the logo: Alt text https://misago-project.org/img.png Amazing, right?'
+# ---
+# name: test_render_ast_to_plaintext_image_with_title_and_alt_text_meta_description
+  'See the logo: Alt text Amazing, right?'
+# ---
+# name: test_render_ast_to_plaintext_image_with_title_meta_description
+  'See the logo: Amazing, right?'
+# ---
 # name: test_render_ast_to_plaintext_inline_code
   'Hello world!'
 # ---
@@ -187,4 +196,10 @@
 # ---
 # name: test_render_ast_to_plaintext_url_meta_description
   'See the site!'
+# ---
+# name: test_render_ast_to_plaintext_url_with_title
+  'See the site (misago forums) https://misago-project.org!'
+# ---
+# name: test_render_ast_to_plaintext_url_with_title_meta_description
+  'See the site (misago forums)!'
 # ---

--- a/misago/parser/tests/__snapshots__/test_plaintext.ambr
+++ b/misago/parser/tests/__snapshots__/test_plaintext.ambr
@@ -92,6 +92,9 @@
 # name: test_render_ast_to_plaintext_image_with_alt_text_meta_description
   'See the logo: Alt text'
 # ---
+# name: test_render_ast_to_plaintext_image_with_title
+  'See the logo: https://misago-project.org/img.png Amazing, right?'
+# ---
 # name: test_render_ast_to_plaintext_inline_code
   'Hello world!'
 # ---

--- a/misago/parser/tests/test_autolink.py
+++ b/misago/parser/tests/test_autolink.py
@@ -68,6 +68,7 @@ def test_autolink_in_url_is_not_parsed(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "<!https://image.com/>"},
                     ],

--- a/misago/parser/tests/test_clean_displayed_url.py
+++ b/misago/parser/tests/test_clean_displayed_url.py
@@ -1,0 +1,61 @@
+from ..urls import clean_displayed_url
+
+
+def test_clean_displayed_url_strips_protocol():
+    result = clean_displayed_url("https://misago-project.org")
+    assert result == "misago-project.org"
+
+
+def test_clean_displayed_url_strips_trailing_slash():
+    result = clean_displayed_url("https://misago-project.org/")
+    assert result == "misago-project.org"
+
+
+def test_clean_displayed_url_keeps_trailing_slash_its_part_of_path():
+    result = clean_displayed_url("https://misago-project.org/lorem/")
+    assert result == "misago-project.org/lorem/"
+
+
+def test_clean_displayed_url_shortens_long_path():
+    result = clean_displayed_url(
+        "https://en.wikipedia.org"
+        "/wiki/Principles_of_user_interface_design_in_common_consumer_electronics"
+    )
+    assert result == "en.wikipedia.org/wiki/Principles_of_...consumer_electronics"
+
+
+def test_clean_displayed_url_keeps_short_query_string():
+    result = clean_displayed_url("https://misago-project.org/?sid=dsa7sdsa")
+    assert result == "misago-project.org/?sid=dsa7sdsa"
+
+
+def test_clean_displayed_url_shortens_long_query_string():
+    result = clean_displayed_url(
+        "https://misago-project.org/?sid=dsa7sdsa8s7a678ds6a786d8sa678d6as8778s6876d8a"
+    )
+    assert result == "misago-project.org/?sid=dsa7sdsa8s..."
+
+
+def test_clean_displayed_url_strips_index_html():
+    result = clean_displayed_url("https://misago-project.org/index.html")
+    assert result == "misago-project.org"
+
+
+def test_clean_displayed_url_strips_index_htm():
+    result = clean_displayed_url("https://misago-project.org/index.htm")
+    assert result == "misago-project.org"
+
+
+def test_clean_displayed_url_strips_index_php():
+    result = clean_displayed_url("https://misago-project.org/index.php")
+    assert result == "misago-project.org"
+
+
+def test_clean_displayed_url_strips_index_before_querystring():
+    result = clean_displayed_url("https://misago-project.org/index.html?hello")
+    assert result == "misago-project.org/?hello"
+
+
+def test_clean_displayed_url_keeps_index_html_if_its_path_segment():
+    result = clean_displayed_url("https://misago-project.org/index.php/")
+    assert result == "misago-project.org/index.php/"

--- a/misago/parser/tests/test_html.py
+++ b/misago/parser/tests/test_html.py
@@ -331,6 +331,24 @@ def test_render_ast_to_html_image_with_alt_text(parser_context, parse_markup, sn
     assert snapshot == render_ast_to_html(parser_context, ast, metadata)
 
 
+def test_render_ast_to_html_image_with_title(parser_context, parse_markup, snapshot):
+    ast = parse_markup(
+        f'See the logo: !(https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_html(parser_context, ast, metadata)
+
+
+def test_render_ast_to_html_image_with_title_and_alt_text(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup(
+        'See the logo: ![Alt text](https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_html(parser_context, ast, metadata)
+
+
 def test_render_ast_to_html_image_bbcode(parser_context, parse_markup, snapshot):
     ast = parse_markup(f"See the logo: [img]https://misago-project.org/img.png[/img]")
     metadata = create_ast_metadata(parser_context, ast)
@@ -349,6 +367,12 @@ def test_render_ast_to_html_image_bbcode_with_alt_text(
 
 def test_render_ast_to_html_url(parser_context, parse_markup, snapshot):
     ast = parse_markup(f"See [*the site*](https://misago-project.org)!")
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_html(parser_context, ast, metadata)
+
+
+def test_render_ast_to_plaintext_url_with_title(parser_context, parse_markup, snapshot):
+    ast = parse_markup('See [*the site*](https://misago-project.org "misago forums")!')
     metadata = create_ast_metadata(parser_context, ast)
     assert snapshot == render_ast_to_html(parser_context, ast, metadata)
 

--- a/misago/parser/tests/test_html_element.py
+++ b/misago/parser/tests/test_html_element.py
@@ -15,6 +15,11 @@ def test_html_element_returns_single_tag_with_str_attribute():
     assert html == '<img src="https://example.com" />'
 
 
+def test_html_element_returns_single_tag_with_empty_alt_attribute():
+    html = html_element("img", attrs={"alt": ""})
+    assert html == '<img alt="" />'
+
+
 def test_html_element_returns_tag_with_content():
     html = html_element("b", "string")
     assert html == "<b>string</b>"

--- a/misago/parser/tests/test_html_element.py
+++ b/misago/parser/tests/test_html_element.py
@@ -1,0 +1,30 @@
+from ..htmlelement import html_element
+
+
+def test_html_element_returns_single_tag():
+    assert html_element("hr") == "<hr />"
+
+
+def test_html_element_returns_single_tag_with_bool_attribute():
+    html = html_element("hr", attrs={"misago-data": True})
+    assert html == "<hr misago-data />"
+
+
+def test_html_element_returns_single_tag_with_str_attribute():
+    html = html_element("img", attrs={"src": "https://example.com"})
+    assert html == '<img src="https://example.com" />'
+
+
+def test_html_element_returns_tag_with_content():
+    html = html_element("b", "string")
+    assert html == "<b>string</b>"
+
+
+def test_html_element_returns_tag_with_empty_content():
+    html = html_element("b", "")
+    assert html == "<b></b>"
+
+
+def test_html_element_returns_tag_with_content_and_attributes():
+    html = html_element("b", "string", {"class": "text-muted", "misago-data": True})
+    assert html == '<b class="text-muted" misago-data>string</b>'

--- a/misago/parser/tests/test_images.py
+++ b/misago/parser/tests/test_images.py
@@ -8,6 +8,7 @@ def test_image(parse_markup):
                 {
                     "type": "image",
                     "alt": None,
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -26,6 +27,7 @@ def test_image_with_alt_text(parse_markup):
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -44,6 +46,7 @@ def test_image_alt_text_whitespace_is_stripped(parse_markup):
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -62,6 +65,7 @@ def test_image_alt_text_is_empty(parse_markup):
                 {
                     "type": "image",
                     "alt": None,
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -80,6 +84,7 @@ def test_image_alt_text_is_not_parsed(parse_markup):
                 {
                     "type": "image",
                     "alt": "*Image Alt*",
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -98,6 +103,104 @@ def test_image_alt_text_reserved_tokens_are_reversed(parse_markup):
                 {
                     "type": "image",
                     "alt": "`Image`",
+                    "title": None,
+                    "src": "https://image.com/img.jpg",
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_image_with_title(parse_markup):
+    result = parse_markup('Hello !(https://image.com/img.jpg "Lorem ipsum")!')
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "image",
+                    "alt": None,
+                    "title": "Lorem ipsum",
+                    "src": "https://image.com/img.jpg",
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_image_title_whitespace_is_stripped(parse_markup):
+    result = parse_markup(
+        'Hello !(https://image.com/img.jpg     "   Lorem ipsum  "   )!'
+    )
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "image",
+                    "alt": None,
+                    "title": "Lorem ipsum",
+                    "src": "https://image.com/img.jpg",
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_image_title_is_empty(parse_markup):
+    result = parse_markup('Hello !(https://image.com/img.jpg "")!')
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "image",
+                    "alt": None,
+                    "title": None,
+                    "src": "https://image.com/img.jpg",
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_image_title_is_not_parsed(parse_markup):
+    result = parse_markup('Hello !(https://image.com/img.jpg "*Lorem ipsum*")!')
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "image",
+                    "alt": None,
+                    "title": "*Lorem ipsum*",
+                    "src": "https://image.com/img.jpg",
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_image_title_reserved_tokens_are_reversed(parse_markup):
+    result = parse_markup('Hello !(https://image.com/img.jpg "`Image`")!')
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "image",
+                    "alt": None,
+                    "title": "`Image`",
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": "!"},
@@ -155,12 +258,14 @@ def test_image_with_alt_text_next_to_another_image_with_alt_text(parse_markup):
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/img.jpg",
                 },
                 {"type": "text", "text": " "},
                 {
                     "type": "image",
                     "alt": "Other Alt",
+                    "title": None,
                     "src": "https://image.com/other.jpg",
                 },
                 {"type": "text", "text": "!"},

--- a/misago/parser/tests/test_plaintext.py
+++ b/misago/parser/tests/test_plaintext.py
@@ -347,6 +347,16 @@ def test_render_ast_to_plaintext_image_with_alt_text(
     assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
 
 
+def test_render_ast_to_plaintext_image_with_title(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup(
+        'See the logo: !(https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
+
+
 def test_render_ast_to_plaintext_image_bbcode(parser_context, parse_markup, snapshot):
     ast = parse_markup("See the logo: [img]https://misago-project.org/img.png[/img]")
     metadata = create_ast_metadata(parser_context, ast)

--- a/misago/parser/tests/test_plaintext.py
+++ b/misago/parser/tests/test_plaintext.py
@@ -357,6 +357,16 @@ def test_render_ast_to_plaintext_image_with_title(
     assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
 
 
+def test_render_ast_to_plaintext_image_with_title_and_alt_text(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup(
+        'See the logo: ![Alt text](https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
+
+
 def test_render_ast_to_plaintext_image_bbcode(parser_context, parse_markup, snapshot):
     ast = parse_markup("See the logo: [img]https://misago-project.org/img.png[/img]")
     metadata = create_ast_metadata(parser_context, ast)
@@ -412,6 +422,36 @@ def test_render_ast_to_plaintext_image_with_alt_text_meta_description(
     )
 
 
+def test_render_ast_to_plaintext_image_with_title_meta_description(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup(
+        'See the logo: !(https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(
+        parser_context,
+        ast,
+        metadata,
+        PlainTextFormat.META_DESCRIPTION,
+    )
+
+
+def test_render_ast_to_plaintext_image_with_title_and_alt_text_meta_description(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup(
+        'See the logo: ![Alt text](https://misago-project.org/img.png "Amazing, right?")'
+    )
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(
+        parser_context,
+        ast,
+        metadata,
+        PlainTextFormat.META_DESCRIPTION,
+    )
+
+
 def test_render_ast_to_plaintext_image_bbcode_meta_description(
     parser_context, parse_markup, snapshot
 ):
@@ -442,6 +482,12 @@ def test_render_ast_to_plaintext_image_bbcode_with_alt_text_meta_description(
 
 def test_render_ast_to_plaintext_url(parser_context, parse_markup, snapshot):
     ast = parse_markup("See [*the site*](https://misago-project.org)!")
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
+
+
+def test_render_ast_to_plaintext_url_with_title(parser_context, parse_markup, snapshot):
+    ast = parse_markup('See [*the site*](https://misago-project.org "misago forums")!')
     metadata = create_ast_metadata(parser_context, ast)
     assert snapshot == render_ast_to_plaintext(parser_context, ast, metadata)
 
@@ -492,6 +538,19 @@ def test_render_ast_to_plaintext_url_meta_description(
     parser_context, parse_markup, snapshot
 ):
     ast = parse_markup("See [*the site*](https://misago-project.org)!")
+    metadata = create_ast_metadata(parser_context, ast)
+    assert snapshot == render_ast_to_plaintext(
+        parser_context,
+        ast,
+        metadata,
+        PlainTextFormat.META_DESCRIPTION,
+    )
+
+
+def test_render_ast_to_plaintext_url_with_title_meta_description(
+    parser_context, parse_markup, snapshot
+):
+    ast = parse_markup('See [*the site*](https://misago-project.org "misago forums")!')
     metadata = create_ast_metadata(parser_context, ast)
     assert snapshot == render_ast_to_plaintext(
         parser_context,

--- a/misago/parser/tests/test_urls.py
+++ b/misago/parser/tests/test_urls.py
@@ -8,6 +8,7 @@ def test_url(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
                     ],
@@ -30,10 +31,12 @@ def test_url_with_image_with_alt_markdown(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [
                         {
                             "type": "image",
                             "alt": "Image Alt",
+                            "title": None,
                             "src": "https://image.com/image.jpg",
                         },
                     ],
@@ -57,10 +60,12 @@ def test_two_urls_with_image_with_alt_markdown(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [
                         {
                             "type": "image",
                             "alt": "Image Alt",
+                            "title": None,
                             "src": "https://image.com/image.jpg",
                         },
                     ],
@@ -69,13 +74,38 @@ def test_two_urls_with_image_with_alt_markdown(parse_markup):
                 {
                     "type": "url",
                     "href": "https://other.com/",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "Image: "},
                         {
                             "type": "image",
                             "alt": "Image Other",
+                            "title": None,
                             "src": "https://image.com/other.jpg",
                         },
+                    ],
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_url_with_title(parse_markup):
+    result = parse_markup(
+        'Hello [link label](https://example.com/Link "Check it out (new design)!")!'
+    )
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Hello "},
+                {
+                    "type": "url",
+                    "href": "https://example.com/Link",
+                    "title": "Check it out (new design)!",
+                    "children": [
+                        {"type": "text", "text": "link label"},
                     ],
                 },
                 {"type": "text", "text": "!"},
@@ -94,6 +124,7 @@ def test_url_with_parenthesis(parse_markup):
                 {
                     "type": "url",
                     "href": "https://example.com/Link_(Film)",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
                     ],
@@ -116,6 +147,7 @@ def test_url_with_multiple_parenthesis(parse_markup):
                 {
                     "type": "url",
                     "href": "https://example.com/Link_(Film)_(Comedy)",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
                     ],
@@ -138,8 +170,32 @@ def test_url_with_nested_parenthesis(parse_markup):
                 {
                     "type": "url",
                     "href": "https://example.com/Link_(Film_(Comedy))",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
+                    ],
+                },
+                {"type": "text", "text": "!"},
+            ],
+        }
+    ]
+
+
+def test_url_with_wikipedia_link(parse_markup):
+    result = parse_markup(
+        "Check this out: [Adwaita](https://en.wikipedia.org/wiki/Adwaita_(design_language))!"
+    )
+    assert result == [
+        {
+            "type": "paragraph",
+            "children": [
+                {"type": "text", "text": "Check this out: "},
+                {
+                    "type": "url",
+                    "href": "https://en.wikipedia.org/wiki/Adwaita_(design_language)",
+                    "title": None,
+                    "children": [
+                        {"type": "text", "text": "Adwaita"},
                     ],
                 },
                 {"type": "text", "text": "!"},
@@ -158,6 +214,7 @@ def test_url_with_missing_closing_parenthesis_is_trimmed_to_last_one(parse_marku
                 {
                     "type": "url",
                     "href": "https://example.com/Link_(Film_(Comedy",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
                     ],
@@ -186,6 +243,7 @@ def test_url_with_missing_closing_parenthesis_next_to_other_url(parse_markup):
                 {
                     "type": "url",
                     "href": "https://example.com/other",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "other link"},
                     ],
@@ -206,6 +264,7 @@ def test_url_with_extra_closing_parenthesis_excludes_them(parse_markup):
                 {
                     "type": "url",
                     "href": "https://example.com/Link_(Film)",
+                    "title": None,
                     "children": [
                         {"type": "text", "text": "link label"},
                     ],
@@ -230,18 +289,21 @@ def test_image_between_two_urls(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [{"type": "text", "text": "Lorem"}],
                 },
                 {"type": "text", "text": " "},
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/image.jpg",
                 },
                 {"type": "text", "text": " "},
                 {
                     "type": "url",
                     "href": "https://other.com/",
+                    "title": None,
                     "children": [{"type": "text", "text": "Ipsum"}],
                 },
                 {"type": "text", "text": "!"},
@@ -263,12 +325,14 @@ def test_image_before_url(parse_markup):
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/image.jpg",
                 },
                 {"type": "text", "text": " "},
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [{"type": "text", "text": "Lorem"}],
                 },
                 {"type": "text", "text": "!"},
@@ -290,12 +354,14 @@ def test_image_after_url(parse_markup):
                 {
                     "type": "url",
                     "href": "https://image.com/",
+                    "title": None,
                     "children": [{"type": "text", "text": "Lorem"}],
                 },
                 {"type": "text", "text": " "},
                 {
                     "type": "image",
                     "alt": "Image Alt",
+                    "title": None,
                     "src": "https://image.com/image.jpg",
                 },
                 {"type": "text", "text": "!"},

--- a/misago/parser/urls.py
+++ b/misago/parser/urls.py
@@ -1,4 +1,4 @@
-def clean_href(href: str) -> str:
+def clean_url(href: str) -> str:
     if href.startswith("://"):
         return "http" + href
     if "://" not in href:

--- a/misago/parser/urls.py
+++ b/misago/parser/urls.py
@@ -6,5 +6,63 @@ def clean_href(href: str) -> str:
     return href
 
 
-def shorten_url(url: str) -> str:
-    pass
+def clean_displayed_url(url: str) -> str:
+    if "://" in url:
+        url = url[url.index("://") + 3 :]
+
+    if "?" in url:
+        url = _clean_displayed_url_querystring(url)
+
+    if "index" in url.lower():
+        url = _clean_displayed_url_index(url)
+
+    if "/" not in url.strip("/"):
+        url = url.strip("/")
+    else:
+        url = _clean_displayed_url_path(url)
+
+    return url
+
+
+QUERYSTRING_LENGTH_LIMIT = 15
+
+
+def _clean_displayed_url_querystring(url: str) -> str:
+    querystring = url[url.index("?") :]
+    if len(querystring) > QUERYSTRING_LENGTH_LIMIT:
+        url = url[: url.index("?")]
+        url += f"{querystring[:QUERYSTRING_LENGTH_LIMIT]}..."
+    return url
+
+
+INDEX_FILE_NAMES = ("index.php", "index.html", "index.htm")
+
+
+def _clean_displayed_url_index(url: str) -> str:
+    for filename in INDEX_FILE_NAMES:
+        if filename in url:
+            start = url.lower().index(filename)
+            stop = start + len(filename)
+            tail = url[stop:]
+            if not tail or tail[0] == "?":
+                return url[:start] + url[stop:]
+
+    return url
+
+
+PATH_MAX_LENGTH = 50
+
+
+def _clean_displayed_url_path(url: str) -> str:
+    start = url.index("/")
+
+    if "?" in url:
+        end = url.index("?")
+    else:
+        end = len(url)
+
+    path = url[start:end]
+    if len(path) > PATH_MAX_LENGTH:
+        return f"{url[:start]}{path[:20]}...{path[-20:]}{url[end:]}"
+
+    return url

--- a/misago/parser/urls.py
+++ b/misago/parser/urls.py
@@ -1,3 +1,6 @@
+from .hooks import clean_displayed_url_hook
+
+
 def clean_url(href: str) -> str:
     if href.startswith("://"):
         return "http" + href
@@ -7,6 +10,10 @@ def clean_url(href: str) -> str:
 
 
 def clean_displayed_url(url: str) -> str:
+    return clean_displayed_url_hook(_clean_displayed_url_action, url)
+
+
+def _clean_displayed_url_action(url: str) -> str:
     if "://" in url:
         url = url[url.index("://") + 3 :]
 

--- a/misago/parser/urls.py
+++ b/misago/parser/urls.py
@@ -4,3 +4,7 @@ def clean_href(href: str) -> str:
     if "://" not in href:
         return "http://" + href
     return href
+
+
+def shorten_url(url: str) -> str:
+    pass

--- a/misago/threads/tests/test_threads_merge_api.py
+++ b/misago/threads/tests/test_threads_merge_api.py
@@ -683,7 +683,6 @@ class ThreadsMergeApiTests(ThreadsApiTestCase):
         self.assertEqual(postreads.filter(thread=new_thread).count(), 2)
         self.assertEqual(postreads.filter(category=self.category).count(), 2)
 
-
     @patch_category_acl({"can_merge_threads": True})
     @patch("misago.threads.api.threadendpoints.merge.delete_duplicate_watched_threads")
     def test_merge_threads_merged_best_answer(


### PR DESCRIPTION
Fixes #1840

# Todo

- [x] Update link pattern
- [x] Update image pattern
- [x] Print link with title in plaintext
- [x] Print image with title in plaintext
- [x] Print link with title in HTML
- [x] Print image with title in HTML
- [x] Add plugin hook to `clean_displayed_url`