### PR TITLE
Improve URL handling in parser

### DIFF
--- a/misago/templates/misago/posting/preview.html
+++ b/misago/templates/misago/posting/preview.html
@@ -7,7 +7,7 @@
     </h3>
   </div>
   <div class="panel-body">
-    <article class="misago-rich-text">
+    <article class="rich-text">
       {% rich_text preview preview_rich_text_data %}
     </article>
   </div>


### PR DESCRIPTION
Fixes #1878

This PR addresses a lot of issues:

- Improves autolink regex
- Improves url validation regex
- Adds support for relative urls in url parser's validation
- Fixed invalid greedy parenthesis matching algorithm
- Replaced consume linebreak at end of thematic break regex with lookahead

Relates to #1723 