### PR TITLE
Set timeout for GH job at 20 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Faker test can hang up, so kill actions if they take longer than 20 minutes. We need ~17 to complete CI run, so those 3 minutes should be safe margin.