### PR TITLE
Add template outlets to Misago's base template

### DIFF
--- a/dev-docs/plugins/template-outlets-reference.md
+++ b/dev-docs/plugins/template-outlets-reference.md
@@ -23,6 +23,26 @@ On the Admin dashboard page, below the Analytics card.
 On the Admin dashboard page, below all other content.
 
 
+## `HEAD_END`
+
+At the end of the head section on all pages.
+
+
+## `BODY_START`
+
+At the start of the body section on all pages.
+
+
+## `BODY_AFTER_SCRIPTS`
+
+In the body section, after Misago's scripts, on all pages.
+
+
+## `BODY_END`
+
+At the end of the body section on all pages.
+
+
 ## `ATTACHMENT_PAGE_START`
 
 On the attachment details page, above the preview.

--- a/misago/plugins/enums.py
+++ b/misago/plugins/enums.py
@@ -14,6 +14,12 @@ class PluginOutlet(Enum):
     )
     ADMIN_DASHBOARD_END = "On the Admin dashboard page, below all other content."
 
+    HEAD_END = "At the end of the head section on all pages."
+
+    BODY_START = "At the start of the body section on all pages."
+    BODY_AFTER_SCRIPTS = "In the body section, after Misago's scripts, on all pages."
+    BODY_END = "At the end of the body section on all pages."
+
     ATTACHMENT_PAGE_START = "On the attachment details page, above the preview."
     ATTACHMENT_PAGE_AFTER_PREVIEW = "On the attachment details page, under the preview."
     ATTACHMENT_PAGE_END = "On the attachment details page, under the details block."

--- a/misago/templates/misago/base.html
+++ b/misago/templates/misago/base.html
@@ -1,4 +1,4 @@
-{% load i18n static misago_absoluteurl misago_json %}
+{% load i18n static misago_absoluteurl misago_json misago_plugins %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE_SHORT }}">
   <head>
@@ -52,14 +52,17 @@
       window.misago_locale = "{{ LANGUAGE_CODE }}"
       window.misago_csrf = {{ CSRF_COOKIE_NAME|safe }}
     </script>
+    {% pluginoutlet HEAD_END %}
   </head>
   <body class="misago-{% if user.is_authenticated %}authenticated{% else %}anonymous{% endif %}{% if misago_agreement %} agreement-overlay-visible{% endif %}">
     <script type="text/javascript">
       document.body.classList.add("misago-javascript")
     </script>
     {% if settings.google_tracking_id %}
-      {% include "misago/analytics.html" %}
+    {% include "misago/analytics.html" %}
     {% endif %}
+
+    {% pluginoutlet BODY_START %}
 
     <div id="auth-message-mount"></div>
     <div id="snackbar-mount"></div>
@@ -97,12 +100,15 @@
     <script src="{% url 'django-i18n' %}?l={{ LANGUAGE_CODE }}&v={{ I18N_VERSION_SIGNATURE }}"></script>
     <script src="{% static 'misago/js/vendor.js' %}"></script>
     <script src="{% static 'misago/js/misago.js' %}"></script>
-    {% include "misago/scripts.html" %}
+    {% pluginoutlet BODY_AFTER_SCRIPTS %}
+
     <script type="text/javascript">
       misago.init({{ frontend_context|as_json }});
     </script>
+  
     {% block modals %}{% endblock modals %}
     {% block javascript %}{% endblock javascript %}
 
+    {% pluginoutlet BODY_END %}
   </body>
 </html>


### PR DESCRIPTION
This PR adds four plugin outlets to Misago's `base.html` template:

- `HEAD_END`
- `BODY_START`
- `BODY_AFTER_SCRIPTS`
- `BODY_END`