### PR TITLE
Update formatting bbcode to respect escaping

### DIFF
--- a/misago/parser/codeargs.py
+++ b/misago/parser/codeargs.py
@@ -7,7 +7,7 @@ CODE_ARGS = re.compile(r"^(?P<info>.+)[;,] *syntax[:=] *(?P<syntax>.+) *$")
 
 
 def parse_code_args(args_str: str) -> dict | None:
-    if args_str.startswith("syntax:") or args_str.startswith("syntax="):
+    if args_str.lower().startswith("syntax:") or args_str.lower().startswith("syntax="):
         syntax = args_str[7:].strip()
         if not syntax:
             return None

--- a/misago/parser/plugins/codebbcode.py
+++ b/misago/parser/plugins/codebbcode.py
@@ -8,13 +8,7 @@ from markdown_it.rules_block.state_block import StateBlock
 from markdown_it.token import Token
 from markdown_it.utils import EnvType, OptionsDict
 
-from ..bbcode import (
-    BBCodeBlockEnd,
-    BBCodeBlockRule,
-    BBCodeBlockStart,
-    bbcode_block_end_rule,
-    bbcode_block_start_rule,
-)
+from ..bbcode import BBCodeBlockRule
 from ..codeargs import parse_code_args
 
 
@@ -24,9 +18,9 @@ def code_bbcode_plugin(md: MarkdownIt):
         "code_bbcode",
         CodeBBCodeBlockRule(
             name="code_bbcode",
+            bbcode="code",
             element="code",
-            start=code_bbcode_start,
-            end=code_bbcode_end,
+            args_parser=parse_code_args,
         ),
         {"alt": ["paragraph"]},
     )
@@ -35,12 +29,14 @@ def code_bbcode_plugin(md: MarkdownIt):
 
 
 class CodeBBCodeBlockRule(BBCodeBlockRule):
+    def __call__(self, *args):
+        return False
+
     def parse_single_line(
         self,
         state: StateBlock,
         startLine: int,
-        start: BBCodeBlockStart,
-        end: BBCodeBlockEnd,
+        silent: bool,
     ):
         content_start = start[3]
         content_end = end[1]
@@ -59,7 +55,6 @@ class CodeBBCodeBlockRule(BBCodeBlockRule):
         startLine: int,
         endLine: int,
         silent: bool,
-        start: BBCodeBlockStart,
     ) -> bool:
         line = startLine
         pos = state.bMarks[line] + state.tShift[line] + start[3]
@@ -109,27 +104,6 @@ class CodeBBCodeBlockRule(BBCodeBlockRule):
             return {"syntax": attrs["syntax"]}
 
         return None
-
-
-def code_bbcode_start(
-    state: StateBlock, line: int
-) -> tuple[str, dict | None, int, int] | None:
-    start = bbcode_block_start_rule("code", state, line, args=True)
-    if not start:
-        return None
-
-    markup, args_str, start, end = start
-
-    if args_str:
-        args = parse_code_args(args_str)
-    else:
-        args = None
-
-    return markup, args, start, end
-
-
-def code_bbcode_end(state: StateBlock, line: int) -> tuple[str, int, int] | None:
-    return bbcode_block_end_rule("code", state, line)
 
 
 def code_bbcode_renderer(

--- a/misago/parser/plugins/formattingbbcode.py
+++ b/misago/parser/plugins/formattingbbcode.py
@@ -40,20 +40,22 @@ def get_formatting_bbcode_rule(name: str, markup: str):
         maximum = state.posMax
         nesting = 1
 
-        while pos <= maximum:
+        while pos < maximum:
             if state.src[pos] == "\\":
                 pos += 2
-                continue
 
-            if state.src[pos : pos + 3].lower() == markup_open:
+            elif state.src[pos : pos + 3].lower() == markup_open:
                 nesting += 1
+                pos += 1
 
-            if state.src[pos : pos + 4].lower() == markup_close:
+            elif state.src[pos : pos + 4].lower() == markup_close:
                 nesting -= 1
                 if nesting == 0:
                     break
+                pos += 1
 
-            pos += 1
+            else:
+                pos += 1
 
         if state.src[pos : pos + 4].lower() != markup_close:
             return False

--- a/misago/parser/plugins/formattingbbcode.py
+++ b/misago/parser/plugins/formattingbbcode.py
@@ -40,7 +40,11 @@ def get_formatting_bbcode_rule(name: str, markup: str):
         maximum = state.posMax
         nesting = 1
 
-        while pos + 4 <= maximum:
+        while pos <= maximum:
+            if state.src[pos] == "\\":
+                pos += 2
+                continue
+
             if state.src[pos : pos + 3].lower() == markup_open:
                 nesting += 1
 

--- a/misago/parser/plugins/imgbbcode.py
+++ b/misago/parser/plugins/imgbbcode.py
@@ -42,13 +42,14 @@ def img_bbcode_rule(state: StateInline, silent: bool):
         content_start = start + 5
 
     pos = content_start
-    while pos + 6 <= maximum:
-        if state.src[pos : pos + 6].lower() == "[/img]":
+    while pos < maximum:
+        if state.src[pos] == "\\":
+            pos += 2
+        elif state.src[pos : pos + 6].lower() == "[/img]":
             break
-
-        pos += 1
-
-    if state.src[pos : pos + 6].lower() != "[/img]":
+        else:
+            pos += 1
+    else:
         return False
 
     content_end = pos

--- a/misago/parser/plugins/quotebbcode.py
+++ b/misago/parser/plugins/quotebbcode.py
@@ -29,9 +29,6 @@ class QuoteBBCodeBlockRule(BBCodeBlockRule):
 
 
 def quote_bbcode_parse_args(args_str: str) -> dict | None:
-    if not args_str:
-        return None
-
     if args := parse_user_post_args(args_str):
         return args
 

--- a/misago/parser/plugins/quotebbcode.py
+++ b/misago/parser/plugins/quotebbcode.py
@@ -3,7 +3,7 @@ import re
 from markdown_it import MarkdownIt
 from markdown_it.rules_block.state_block import StateBlock
 
-from ..bbcode import BBCodeBlockRule, bbcode_block_end_rule, bbcode_block_start_rule
+from ..bbcode import BBCodeBlockRule
 
 
 def quote_bbcode_plugin(md: MarkdownIt):
@@ -12,9 +12,9 @@ def quote_bbcode_plugin(md: MarkdownIt):
         "quote_bbcode",
         QuoteBBCodeBlockRule(
             name="quote_bbcode",
+            bbcode="quote",
             element="misago-quote",
-            start=quote_bbcode_start,
-            end=quote_bbcode_end,
+            args_parser=quote_bbcode_parse_args,
         ),
         {"alt": ["paragraph"]},
     )
@@ -26,23 +26,6 @@ class QuoteBBCodeBlockRule(BBCodeBlockRule):
             return {"post": attrs["post"]}
 
         return None
-
-
-def quote_bbcode_start(
-    state: StateBlock, line: int
-) -> tuple[str, dict | None, int, int] | None:
-    start = bbcode_block_start_rule("quote", state, line, args=True)
-    if not start:
-        return None
-
-    markup, args_str, start, end = start
-
-    if args_str:
-        args = quote_bbcode_parse_args(args_str)
-    else:
-        args = None
-
-    return markup, args, start, end
 
 
 def quote_bbcode_parse_args(args_str: str) -> dict | None:
@@ -77,7 +60,3 @@ def parse_user_post_args(args: str) -> dict | None:
         return {"user": user, "post": post}
 
     return None
-
-
-def quote_bbcode_end(state: StateBlock, line: int) -> tuple[str, int, int] | None:
-    return bbcode_block_end_rule("quote", state, line)

--- a/misago/parser/plugins/spoilerbbcode.py
+++ b/misago/parser/plugins/spoilerbbcode.py
@@ -1,7 +1,7 @@
 from markdown_it import MarkdownIt
 from markdown_it.rules_block.state_block import StateBlock
 
-from ..bbcode import BBCodeBlockRule, bbcode_block_end_rule, bbcode_block_start_rule
+from ..bbcode import BBCodeBlockRule
 
 
 def spoiler_bbcode_plugin(md: MarkdownIt):
@@ -10,30 +10,13 @@ def spoiler_bbcode_plugin(md: MarkdownIt):
         "spoiler_bbcode",
         BBCodeBlockRule(
             name="spoiler_bbcode",
+            bbcode="spoiler",
             element="misago-spoiler",
-            start=spoiler_bbcode_start,
-            end=spoiler_bbcode_end,
+            args_parser=spoiler_bbcode_parse_args,
         ),
         {"alt": ["paragraph"]},
     )
 
 
-def spoiler_bbcode_start(
-    state: StateBlock, line: int
-) -> tuple[str, dict | None, int, int] | None:
-    start = bbcode_block_start_rule("spoiler", state, line, args=True)
-    if not start:
-        return None
-
-    markup, args_str, start, end = start
-
-    if args_str:
-        args = {"info": args_str}
-    else:
-        args = None
-
-    return markup, args, start, end
-
-
-def spoiler_bbcode_end(state: StateBlock, line: int) -> tuple[str, int, int] | None:
-    return bbcode_block_end_rule("spoiler", state, line)
+def spoiler_bbcode_parse_args(args_str: str) -> dict:
+    return {"info": args_str}

--- a/misago/parser/plugins/urlbbcode.py
+++ b/misago/parser/plugins/urlbbcode.py
@@ -44,13 +44,14 @@ def url_bbcode_rule(state: StateInline, silent: bool):
         content_start = start + 5
 
     pos = content_start
-    while pos + 6 <= maximum:
-        if state.src[pos : pos + 6].lower() == "[/url]":
+    while pos < maximum:
+        if state.src[pos] == "\\":
+            pos += 2
+        elif state.src[pos : pos + 6].lower() == "[/url]":
             break
-
-        pos += 1
-
-    if state.src[pos : pos + 6].lower() != "[/url]":
+        else:
+            pos += 1
+    else:
         return False
 
     content_end = pos

--- a/misago/parser/tests/test_bbcode_block_rule.py
+++ b/misago/parser/tests/test_bbcode_block_rule.py
@@ -193,3 +193,17 @@ def test_bbcode_block_rule_matches_closest_multiline_block_open_close_pair(
 ):
     html = parse_to_html("[quote]\n[quote]\ntext\n[/quote]")
     assert html == ("<p>[quote]</p>\n<misago-quote>\n<p>text</p>\n</misago-quote>")
+
+
+def test_bbcode_block_rule_dosenst_parse_multiline_block_with_escaped_opening(
+    parse_to_html,
+):
+    html = parse_to_html("\\[quote]\ntext\n[/quote]")
+    assert html == "<p>[quote]<br>\ntext<br>\n[/quote]</p>"
+
+
+def test_bbcode_block_rule_dosenst_parse_multiline_block_with_escaped_closing(
+    parse_to_html,
+):
+    html = parse_to_html("[quote]\ntext\n\\[/quote]")
+    assert html == "<p>[quote]<br>\ntext<br>\n[/quote]</p>"

--- a/misago/parser/tests/test_bbcode_block_rule.py
+++ b/misago/parser/tests/test_bbcode_block_rule.py
@@ -29,29 +29,86 @@ def test_bbcode_block_rule_parses_single_line_block_contents(parse_to_html):
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block(parse_to_html):
+def test_bbcode_block_rule_parses_single_line_block_args(parse_to_html):
+    html = parse_to_html("[quote=Hello world]lorem **ipsum** dolor[/quote]")
+    assert html == (
+        '<misago-quote info="Hello world">'
+        "\n<p>lorem <strong>ipsum</strong> dolor</p>\n"
+        "</misago-quote>"
+    )
+
+
+def test_bbcode_block_rule_matches_first_opening_block(parse_to_html):
+    html = parse_to_html("[quote]hello[quote]text[/quote]")
+    assert html == "<misago-quote>\n<p>hello[quote]text</p>\n</misago-quote>"
+
+
+def test_bbcode_block_rule_matches_last_closing_block(parse_to_html):
+    html = parse_to_html("[quote]hello[/quote]text[/quote]")
+    assert html == "<misago-quote>\n<p>hello[/quote]text</p>\n</misago-quote>"
+
+
+def test_bbcode_block_rule_parses_single_line_block_with_spaces_prefix(parse_to_html):
+    html = parse_to_html("paragraph\n  [quote]text[/quote]")
+    assert html == ("<p>paragraph</p>" "\n<misago-quote>\n<p>text</p>\n</misago-quote>")
+
+
+def test_bbcode_block_rule_parses_single_line_block_with_spaces_suffix(parse_to_html):
+    html = parse_to_html("[quote]text[/quote]    \nparagraph")
+    assert html == ("<misago-quote>\n<p>text</p>\n</misago-quote>" "\n<p>paragraph</p>")
+
+
+def test_bbcode_block_rule_dosenst_parse_single_line_block_preceded_by_other_characters(
+    parse_to_html,
+):
+    html = parse_to_html("paragraph[quote]text[/quote]")
+    assert html == "<p>paragraph[quote]text[/quote]</p>"
+
+
+def test_bbcode_block_rule_dosenst_parse_single_line_block_followed_by_other_characters(
+    parse_to_html,
+):
+    html = parse_to_html("[quote]text[/quote]paragraph")
+    assert html == "<p>[quote]text[/quote]paragraph</p>"
+
+
+def test_bbcode_block_rule_dosenst_parse_single_line_block_with_escaped_opening(
+    parse_to_html,
+):
+    html = parse_to_html("\\[quote]text[/quote]")
+    assert html == "<p>[quote]text[/quote]</p>"
+
+
+def test_bbcode_block_rule_dosenst_parse_single_line_block_with_escaped_closing(
+    parse_to_html,
+):
+    html = parse_to_html("[quote]text\\[/quote]")
+    assert html == "<p>[quote]text[/quote]</p>"
+
+
+def _test_bbcode_block_rule_parses_multiline_block(parse_to_html):
     html = parse_to_html("[quote]\ntext\n[/quote]")
     assert html == "<misago-quote>\n<p>text</p>\n</misago-quote>"
 
 
-def test_bbcode_block_rule_parses_multiline_block_contents(parse_to_html):
+def _test_bbcode_block_rule_parses_multiline_block_contents(parse_to_html):
     html = parse_to_html("[quote]\nlorem **ipsum** dolor\n[/quote]")
     assert html == (
         "<misago-quote>\n<p>lorem <strong>ipsum</strong> dolor</p>\n</misago-quote>"
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block_after_paragraph(parse_to_html):
+def _test_bbcode_block_rule_parses_multiline_block_after_paragraph(parse_to_html):
     html = parse_to_html("paragraph\n[quote]\ntext\n[/quote]")
     assert html == "<p>paragraph</p>\n<misago-quote>\n<p>text</p>\n</misago-quote>"
 
 
-def test_bbcode_block_rule_parses_multiline_block_before_paragraph(parse_to_html):
+def _test_bbcode_block_rule_parses_multiline_block_before_paragraph(parse_to_html):
     html = parse_to_html("[quote]\ntext\n[/quote]\nparagraph")
     assert html == "<misago-quote>\n<p>text</p>\n</misago-quote>\n<p>paragraph</p>"
 
 
-def test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_html):
+def _test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_html):
     html = parse_to_html("paragraph1\n[quote]\ntext\n[/quote]\nparagraph2")
     assert html == (
         "<p>paragraph1</p>"
@@ -60,7 +117,7 @@ def test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_ht
     )
 
 
-def test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to_html):
+def _test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to_html):
     html = parse_to_html("[quote]\n[quote]nested[/quote]\n[/quote]")
     assert html == (
         "<misago-quote>"
@@ -71,7 +128,7 @@ def test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to_
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
+def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[quote]\nnested\n[/quote]\n[/quote]")
@@ -84,7 +141,7 @@ def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type(
+def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[spoiler]\nnested\n[/spoiler]\n[/quote]")
@@ -97,7 +154,7 @@ def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_between_paragraphs(
+def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_between_paragraphs(
     parse_to_html,
 ):
     html = parse_to_html(
@@ -114,7 +171,7 @@ def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_be
     )
 
 
-def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type_between_paragraphs(
+def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type_between_paragraphs(
     parse_to_html,
 ):
     html = parse_to_html(
@@ -131,7 +188,7 @@ def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of
     )
 
 
-def test_bbcode_block_rule_matches_closest_multiline_block_open_close_pair(
+def _test_bbcode_block_rule_matches_closest_multiline_block_open_close_pair(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[quote]\ntext\n[/quote]")

--- a/misago/parser/tests/test_bbcode_block_rule.py
+++ b/misago/parser/tests/test_bbcode_block_rule.py
@@ -86,29 +86,29 @@ def test_bbcode_block_rule_dosenst_parse_single_line_block_with_escaped_closing(
     assert html == "<p>[quote]text[/quote]</p>"
 
 
-def _test_bbcode_block_rule_parses_multiline_block(parse_to_html):
+def test_bbcode_block_rule_parses_multiline_block(parse_to_html):
     html = parse_to_html("[quote]\ntext\n[/quote]")
     assert html == "<misago-quote>\n<p>text</p>\n</misago-quote>"
 
 
-def _test_bbcode_block_rule_parses_multiline_block_contents(parse_to_html):
+def test_bbcode_block_rule_parses_multiline_block_contents(parse_to_html):
     html = parse_to_html("[quote]\nlorem **ipsum** dolor\n[/quote]")
     assert html == (
         "<misago-quote>\n<p>lorem <strong>ipsum</strong> dolor</p>\n</misago-quote>"
     )
 
 
-def _test_bbcode_block_rule_parses_multiline_block_after_paragraph(parse_to_html):
+def test_bbcode_block_rule_parses_multiline_block_after_paragraph(parse_to_html):
     html = parse_to_html("paragraph\n[quote]\ntext\n[/quote]")
     assert html == "<p>paragraph</p>\n<misago-quote>\n<p>text</p>\n</misago-quote>"
 
 
-def _test_bbcode_block_rule_parses_multiline_block_before_paragraph(parse_to_html):
+def test_bbcode_block_rule_parses_multiline_block_before_paragraph(parse_to_html):
     html = parse_to_html("[quote]\ntext\n[/quote]\nparagraph")
     assert html == "<misago-quote>\n<p>text</p>\n</misago-quote>\n<p>paragraph</p>"
 
 
-def _test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_html):
+def test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_html):
     html = parse_to_html("paragraph1\n[quote]\ntext\n[/quote]\nparagraph2")
     assert html == (
         "<p>paragraph1</p>"
@@ -117,7 +117,7 @@ def _test_bbcode_block_rule_parses_multiline_block_between_paragraphs(parse_to_h
     )
 
 
-def _test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to_html):
+def test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to_html):
     html = parse_to_html("[quote]\n[quote]nested[/quote]\n[/quote]")
     assert html == (
         "<misago-quote>"
@@ -128,7 +128,7 @@ def _test_bbcode_block_rule_parses_single_line_block_in_multiline_block(parse_to
     )
 
 
-def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
+def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[quote]\nnested\n[/quote]\n[/quote]")
@@ -141,7 +141,7 @@ def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block(
     )
 
 
-def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type(
+def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[spoiler]\nnested\n[/spoiler]\n[/quote]")
@@ -154,7 +154,7 @@ def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_o
     )
 
 
-def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_between_paragraphs(
+def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_between_paragraphs(
     parse_to_html,
 ):
     html = parse_to_html(
@@ -171,7 +171,7 @@ def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_b
     )
 
 
-def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type_between_paragraphs(
+def test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_of_other_type_between_paragraphs(
     parse_to_html,
 ):
     html = parse_to_html(
@@ -188,7 +188,7 @@ def _test_bbcode_block_rule_parses_multiline_block_with_nested_multiline_block_o
     )
 
 
-def _test_bbcode_block_rule_matches_closest_multiline_block_open_close_pair(
+def test_bbcode_block_rule_matches_closest_multiline_block_open_close_pair(
     parse_to_html,
 ):
     html = parse_to_html("[quote]\n[quote]\ntext\n[/quote]")

--- a/misago/parser/tests/test_code_bbcode.py
+++ b/misago/parser/tests/test_code_bbcode.py
@@ -92,3 +92,17 @@ def test_code_bbcode_with_quoted_arg_single_line(parse_to_html):
 def test_code_bbcode_single_line_strips_whitespace(parse_to_html):
     html = parse_to_html('[code="lorem"]   hello("world")   [/code]')
     assert html == '<misago-code info="lorem">hello(&quot;world&quot;)</misago-code>'
+
+
+def test_code_bbcode_between_paragraphs(parse_to_html):
+    html = parse_to_html("paragraph1\n[code]\nhello()\n[/code]\nparagraph2")
+    assert html == (
+        "<p>paragraph1</p>" "\n<misago-code>hello()</misago-code>" "\n<p>paragraph2</p>"
+    )
+
+
+def test_code_bbcode_single_line_between_paragraphs(parse_to_html):
+    html = parse_to_html("paragraph1\n[code]hello()[/code]\nparagraph2")
+    assert html == (
+        "<p>paragraph1</p>" "\n<misago-code>hello()</misago-code>" "\n<p>paragraph2</p>"
+    )

--- a/misago/parser/tests/test_formatting_bbcode.py
+++ b/misago/parser/tests/test_formatting_bbcode.py
@@ -29,6 +29,11 @@ def test_nested_same_formatting_bbcode(parse_to_html):
 
 
 def test_formatting_bbcode_with_escaped_closing_tag(parse_to_html):
+    html = parse_to_html("Hello [b]world\\[/b]")
+    assert html == "<p>Hello [b]world[/b]</p>"
+
+
+def test_formatting_bbcode_with_nested_escaped_closing_tag(parse_to_html):
     html = parse_to_html("Hello [b]wor\[/b]ld[/b]!")
     assert html == "<p>Hello <b>wor[/b]ld</b>!</p>"
 

--- a/misago/parser/tests/test_formatting_bbcode.py
+++ b/misago/parser/tests/test_formatting_bbcode.py
@@ -23,9 +23,14 @@ def test_nested_formatting_bbcode(parse_to_html):
     assert html == "<p>Hello <b>wo<u>r</u>ld</b>!</p>"
 
 
-def test_nested_sameformatting_bbcode(parse_to_html):
+def test_nested_same_formatting_bbcode(parse_to_html):
     html = parse_to_html("Hello [b]wo[b]r[/b]ld[/b]!")
     assert html == "<p>Hello <b>world</b>!</p>"
+
+
+def test_formatting_bbcode_with_escaped_closing_tag(parse_to_html):
+    html = parse_to_html("Hello [b]wor\[/b]ld[/b]!")
+    assert html == "<p>Hello <b>wor[/b]ld</b>!</p>"
 
 
 def test_formatting_bbcode_parses_contents(parse_to_html):

--- a/misago/parser/tests/test_img_bbcode.py
+++ b/misago/parser/tests/test_img_bbcode.py
@@ -41,3 +41,19 @@ def test_img_bbcode_with_quoted_arg(parse_to_html):
 def test_img_bbcode_with_invalid_arg(parse_to_html):
     html = parse_to_html("[img=invalid]Hello[/img]")
     assert html == '<p><img src="invalid" alt="Hello"></p>'
+
+
+def test_img_bbcode_with_escaped_closing_tag(parse_to_html):
+    html = parse_to_html("[img=example.com/kitten.png]Hello\\[/img]")
+    assert html == (
+        "<p>"
+        "["
+        "<a "
+        'href="http://img=example.com/kitten.png" '
+        'rel="external nofollow noopener" '
+        'target="_blank" '
+        'misago-rich-text="autolink"'
+        ">"
+        "img=example.com/kitten.png</a>]Hello[/img]"
+        "</p>"
+    )

--- a/misago/parser/tests/test_url_bbcode.py
+++ b/misago/parser/tests/test_url_bbcode.py
@@ -96,3 +96,19 @@ def test_url_bbcode_with_arg_parses_content(parse_to_html):
         "</a>"
         "</p>"
     )
+
+
+def test_url_bbcode_with_escaped_closing_tag(parse_to_html):
+    html = parse_to_html("[url=example.com]Hello\\[/url]")
+    assert html == (
+        "<p>"
+        "["
+        "<a "
+        'href="http://url=example.com" '
+        'rel="external nofollow noopener" '
+        'target="_blank" '
+        'misago-rich-text="autolink"'
+        ">"
+        "url=example.com</a>]Hello[/url]"
+        "</p>"
+    )


### PR DESCRIPTION
Fixes #1929
Fixes #1936
Fixes #1928

# TODO

- [x] Formatting BBCode
- [x] `img`
- [x] `url`
- [x] Single line BBCode blocks
- [x] Multiple line BBCode blocks
- [x] `quote`
- [x] `code`
- [x] `spoiler`