### PR TITLE
Fix pairs matching algo in split inline token being incorrect

### DIFF
--- a/misago/parser/tests/test_attachments.py
+++ b/misago/parser/tests/test_attachments.py
@@ -162,3 +162,14 @@ def test_attachment_breaks_list_item(parse_to_html):
         "\n</li>"
         "\n</ol>"
     )
+
+
+def test_attachment_doesnt_break_siblings_parsing(parse_to_html):
+    html = parse_to_html("Lorem **ipsum**<attachment=image.png:12>__dolor__ met.")
+    assert html == (
+        "<p>Lorem <strong>ipsum</strong></p>"
+        '\n<div class="rich-text-selection-boundary" misago-selection-boundary="true"></div>'
+        '\n<misago-attachment name="image.png" slug="image-png" id="12">'
+        '\n<div class="rich-text-selection-boundary" misago-selection-boundary="true"></div>'
+        "\n<p><strong>dolor</strong> met.</p>"
+    )

--- a/misago/parser/tests/test_split_inline_token.py
+++ b/misago/parser/tests/test_split_inline_token.py
@@ -51,7 +51,7 @@ def test_split_inline_token_strips_spaces(parse_to_raw_tokens):
     assert split_tokens[2].children[0].content == "dolor"
 
 
-def test_split_inline_token_strips_softbreaks(parse_to_raw_tokens):
+def test_split_inline_token_strips_hardbreaks(parse_to_raw_tokens):
     tokens = parse_to_raw_tokens("lorem \n @ipsum \n dolor")
     assert tokens[1].type == "inline"
 
@@ -123,3 +123,23 @@ def test_split_inline_token_replaces_split_inline_tags(parse_to_raw_tokens):
     assert split_tokens[2].type == "mention"
     assert split_tokens[3].type == "inline"
     assert split_tokens[3].children[0].content == "[/u] [/b]   met"
+
+
+def test_split_inline_token_doesnt_replaces_sibling_inline_tags(parse_to_raw_tokens):
+    tokens = parse_to_raw_tokens("lorem [b]ipsum[/b]\n**dolor** met")
+    assert tokens[1].type == "inline"
+
+    split_tokens = split_inline_token(tokens[1], "br")
+    assert len(split_tokens) == 3
+
+    assert split_tokens[0].type == "inline"
+    assert split_tokens[0].children[0].content == "lorem "
+    assert split_tokens[0].children[1].type == "bold_bbcode_open"
+    assert split_tokens[0].children[2].content == "ipsum"
+    assert split_tokens[0].children[3].type == "bold_bbcode_close"
+    assert split_tokens[1].type == "softbreak"
+    assert split_tokens[2].type == "inline"
+    assert split_tokens[2].children[0].type == "strong_open"
+    assert split_tokens[2].children[1].content == "dolor"
+    assert split_tokens[2].children[2].type == "strong_close"
+    assert split_tokens[2].children[3].content == " met"

--- a/misago/parser/tokens.py
+++ b/misago/parser/tokens.py
@@ -367,9 +367,9 @@ def inline_token_remove_orphaned_children(token: Token) -> Token | None:
     stack: list[tuple[int, str]] = []
     for index, child in enumerate(token.children):
         if child.nesting == 1:
-            stack.append((index, child.type))
+            stack.append((index, child.tag))
         if child.nesting == -1:
-            if not stack or stack[-1][1] != child.type:
+            if not stack or stack[-1][1] != child.tag:
                 new_children.append(
                     Token(
                         type="text",


### PR DESCRIPTION
`inline_token_remove_orphaned_children` compared tokens via `type` attribute, which wouldn't work as `token_open != token_close`. Replaced this with `tag`.

Fixes #1932