### PR TITLE
Add hook for new private thread member validator

### DIFF
--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -11,6 +11,7 @@ Hooks instances are importable from the following Python modules:
 - [`misago.permissions.hooks`](#misago-permissions-hooks)
 - [`misago.polls.hooks`](#misago-polls-hooks)
 - [`misago.posting.hooks`](#misago-posting-hooks)
+- [`misago.privatethreads.hooks`](#misago-privatethreads-hooks)
 - [`misago.threads.hooks`](#misago-threads-hooks)
 - [`misago.threadupdates.hooks`](#misago-threadupdates-hooks)
 - [`misago.users.hooks`](#misago-users-hooks)
@@ -163,6 +164,13 @@ Hooks instances are importable from the following Python modules:
 - [`validate_post_hook`](./validate-post-hook.md)
 - [`validate_posted_contents_hook`](./validate-posted-contents-hook.md)
 - [`validate_thread_title_hook`](./validate-thread-title-hook.md)
+
+
+## `misago.privatethreads.hooks`
+
+`misago.privatethreads.hooks` defines the following hooks:
+
+- [`validate_new_private_thread_member_hook`](./validate-new-private-thread-member-hook.md)
 
 
 ## `misago.threads.hooks`

--- a/dev-docs/plugins/hooks/validate-new-private-thread-member-hook.md
+++ b/dev-docs/plugins/hooks/validate-new-private-thread-member-hook.md
@@ -1,0 +1,132 @@
+# `validate_new_private_thread_member_hook`
+
+This hook allows plugins to replace or extend the standard logic for validating new private thread members.
+
+
+## Location
+
+This hook can be imported from `misago.privatethreads.hooks`:
+
+```python
+from misago.privatethreads.hooks import validate_new_private_thread_member_hook
+```
+
+
+## Filter
+
+```python
+def custom_validate_new_private_thread_member_filter(
+    action: ValidateNewPrivateThreadMemberHookAction,
+    invited_user_permissions: 'UserPermissionsProxy',
+    other_user_permissions: 'UserPermissionsProxy',
+    cache_versions: dict,
+    request: HttpRequest | None=None,
+):
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: ValidateNewPrivateThreadMemberHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `invited_user_permissions: UserPermissionsProxy`
+
+A proxy object with the invited user's permissions.
+
+
+#### `other_user_permissions: UserPermissionsProxy`
+
+A proxy object with the inviting user's permissions.
+
+
+#### `cache_versions: dict`
+
+A Python `dict` with cache versions.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+## Action
+
+```python
+def validate_new_private_thread_member_action(
+    invited_user_permissions: 'UserPermissionsProxy',
+    other_user_permissions: 'UserPermissionsProxy',
+    cache_versions: dict,
+    request: HttpRequest | None=None,
+):
+    ...
+```
+
+Misago function for validating new private thread members.
+
+
+### Arguments
+
+#### `invited_user_permissions: UserPermissionsProxy`
+
+A proxy object with the invited user's permissions.
+
+
+#### `other_user_permissions: UserPermissionsProxy`
+
+A proxy object with the inviting user's permissions.
+
+
+#### `cache_versions: dict`
+
+A Python `dict` with cache versions.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+## Example
+
+Block new users from inviting non-staff users to their private threads.
+
+```python
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.http import HttpRequest
+from django.utils import timezone
+from misago.permissions.proxy import UserPermissionsProxy
+from misago.privatethreads.hooks import validate_new_private_thread_member_hook
+
+
+@validate_new_private_thread_member_hook.append_filter
+def validate_new_private_thread_member_registration_date(
+    action,
+    invited_user_permissions: UserPermissionsProxy,
+    other_user_permissions: UserPermissionsProxy,
+    cache_versions: dict,
+    request: HttpRequest | None = None,
+):
+    action(
+        invited_user_permissions,
+        other_user_permissions,
+        cache_versions,
+        request,
+    )
+
+    user_is_new = (timezone.now() - user.joined_on).days < 7
+
+    if user_is_new and not invited_user_permissions.moderated_categories:
+        raise ValidationError(
+            "Your account is less than 7 days old."
+        )
+```

--- a/misago/posting/forms/inviteusers.py
+++ b/misago/posting/forms/inviteusers.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 from django.utils.translation import pgettext
 
 from ...permissions.proxy import UserPermissionsProxy
-from ...privatethreads.validators import validate_can_invite_user
+from ...privatethreads.validators import validate_new_private_thread_member
 from ...users.fields import UserMultipleChoiceField
 from ..state import StartPrivateThreadState
 from .base import PostingForm
@@ -55,7 +55,7 @@ class InviteUsersForm(PostingForm):
 
         for user in data:
             try:
-                validate_can_invite_user(
+                validate_new_private_thread_member(
                     UserPermissionsProxy(user, cache_versions),
                     request.user_permissions,
                     cache_versions,

--- a/misago/privatethreads/hooks/__init__.py
+++ b/misago/privatethreads/hooks/__init__.py
@@ -1,0 +1,5 @@
+from .validate_new_private_thread_member import validate_new_private_thread_member_hook
+
+__all__ = [
+    "validate_new_private_thread_member_hook",
+]

--- a/misago/privatethreads/hooks/validate_new_private_thread_member.py
+++ b/misago/privatethreads/hooks/validate_new_private_thread_member.py
@@ -1,0 +1,150 @@
+from typing import TYPE_CHECKING, Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+
+if TYPE_CHECKING:
+    from ...permissions.proxy import UserPermissionsProxy
+
+
+class ValidateNewPrivateThreadMemberHookAction(Protocol):
+    """
+    Misago function for validating new private thread members.
+
+    # Arguments
+
+    ## `invited_user_permissions: UserPermissionsProxy`
+
+    A proxy object with the invited user's permissions.
+
+    ## `other_user_permissions: UserPermissionsProxy`
+
+    A proxy object with the inviting user's permissions.
+
+    ## `cache_versions: dict`
+
+    A Python `dict` with cache versions.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+    """
+
+    def __call__(
+        self,
+        invited_user_permissions: "UserPermissionsProxy",
+        other_user_permissions: "UserPermissionsProxy",
+        cache_versions: dict,
+        request: HttpRequest | None = None,
+    ): ...
+
+
+class ValidateNewPrivateThreadMemberHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: ValidateNewPrivateThreadMemberHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `invited_user_permissions: UserPermissionsProxy`
+
+    A proxy object with the invited user's permissions.
+
+    ## `other_user_permissions: UserPermissionsProxy`
+
+    A proxy object with the inviting user's permissions.
+
+    ## `cache_versions: dict`
+
+    A Python `dict` with cache versions.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+    """
+
+    def __call__(
+        self,
+        action: ValidateNewPrivateThreadMemberHookAction,
+        invited_user_permissions: "UserPermissionsProxy",
+        other_user_permissions: "UserPermissionsProxy",
+        cache_versions: dict,
+        request: HttpRequest | None = None,
+    ): ...
+
+
+class ValidateNewPrivateThreadMemberHook(
+    FilterHook[
+        ValidateNewPrivateThreadMemberHookAction,
+        ValidateNewPrivateThreadMemberHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the standard logic for
+    validating new private thread members.
+
+    # Example
+
+    Block new users from inviting non-staff users to their private threads.
+
+    ```python
+    from datetime import timedelta
+
+    from django.core.exceptions import ValidationError
+    from django.http import HttpRequest
+    from django.utils import timezone
+    from misago.permissions.proxy import UserPermissionsProxy
+    from misago.privatethreads.hooks import validate_new_private_thread_member_hook
+
+
+    @validate_new_private_thread_member_hook.append_filter
+    def validate_new_private_thread_member_registration_date(
+        action,
+        invited_user_permissions: UserPermissionsProxy,
+        other_user_permissions: UserPermissionsProxy,
+        cache_versions: dict,
+        request: HttpRequest | None = None,
+    ):
+        action(
+            invited_user_permissions,
+            other_user_permissions,
+            cache_versions,
+            request,
+        )
+
+        user_is_new = (timezone.now() - user.joined_on).days < 7
+
+        if user_is_new and not invited_user_permissions.moderated_categories:
+            raise ValidationError(
+                "Your account is less than 7 days old."
+            )
+    ```
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: ValidateNewPrivateThreadMemberHookAction,
+        invited_user_permissions: "UserPermissionsProxy",
+        other_user_permissions: "UserPermissionsProxy",
+        cache_versions: dict,
+        request: HttpRequest | None = None,
+    ):
+        return super().__call__(
+            action,
+            invited_user_permissions,
+            other_user_permissions,
+            cache_versions,
+            request,
+        )
+
+
+validate_new_private_thread_member_hook = ValidateNewPrivateThreadMemberHook()

--- a/misago/privatethreads/tests/test_validate_new_private_thread_member.py
+++ b/misago/privatethreads/tests/test_validate_new_private_thread_member.py
@@ -3,24 +3,24 @@ from django.core.exceptions import ValidationError
 
 from ...permissions.proxy import UserPermissionsProxy
 from ...users.bans import ban_user
-from ..validators import validate_can_invite_user
+from ..validators import validate_new_private_thread_member
 
 
-def test_validate_can_invite_user_passes(user, other_user, cache_versions):
-    validate_can_invite_user(
+def test_validate_new_private_thread_member_passes(user, other_user, cache_versions):
+    validate_new_private_thread_member(
         UserPermissionsProxy(user, cache_versions),
         UserPermissionsProxy(other_user, cache_versions),
         cache_versions,
     )
 
 
-def test_validate_can_invite_user_fails_for_banned_user(
+def test_validate_new_private_thread_member_fails_for_banned_user(
     user, other_user, cache_versions
 ):
     ban_user(user)
 
     with pytest.raises(ValidationError) as exc_info:
-        validate_can_invite_user(
+        validate_new_private_thread_member(
             UserPermissionsProxy(user, cache_versions),
             UserPermissionsProxy(other_user, cache_versions),
             cache_versions,
@@ -29,14 +29,14 @@ def test_validate_can_invite_user_fails_for_banned_user(
     assert exc_info.value.messages == ["This user is banned."]
 
 
-def test_validate_can_invite_user_fails_for_user_without_private_threads_permission(
+def test_validate_new_private_thread_member_fails_for_user_without_private_threads_permission(
     user, other_user, members_group, cache_versions
 ):
     members_group.can_use_private_threads = False
     members_group.save()
 
     with pytest.raises(ValidationError) as exc_info:
-        validate_can_invite_user(
+        validate_new_private_thread_member(
             UserPermissionsProxy(user, cache_versions),
             UserPermissionsProxy(other_user, cache_versions),
             cache_versions,
@@ -45,14 +45,14 @@ def test_validate_can_invite_user_fails_for_user_without_private_threads_permiss
     assert exc_info.value.messages == ["This user can't use private threads."]
 
 
-def test_validate_can_invite_user_fails_for_user_who_disabled_private_thread_invites(
+def test_validate_new_private_thread_member_fails_for_user_who_disabled_private_thread_invites(
     user, other_user, cache_versions
 ):
     user.limits_private_thread_invites_to = user.LIMIT_INVITES_TO_NOBODY
     user.save()
 
     with pytest.raises(ValidationError) as exc_info:
-        validate_can_invite_user(
+        validate_new_private_thread_member(
             UserPermissionsProxy(user, cache_versions),
             UserPermissionsProxy(other_user, cache_versions),
             cache_versions,
@@ -63,27 +63,27 @@ def test_validate_can_invite_user_fails_for_user_who_disabled_private_thread_inv
     ]
 
 
-def test_validate_can_invite_user_passes_moderator_for_user_who_disabled_private_thread_invites(
+def test_validate_new_private_thread_member_passes_moderator_for_user_who_disabled_private_thread_invites(
     user, moderator, cache_versions
 ):
     user.limits_private_thread_invites_to = user.LIMIT_INVITES_TO_NOBODY
     user.save()
 
-    validate_can_invite_user(
+    validate_new_private_thread_member(
         UserPermissionsProxy(user, cache_versions),
         UserPermissionsProxy(moderator, cache_versions),
         cache_versions,
     )
 
 
-def test_validate_can_invite_user_fails_for_user_who_limits_private_thread_invites_to_followed(
+def test_validate_new_private_thread_member_fails_for_user_who_limits_private_thread_invites_to_followed(
     user, other_user, cache_versions
 ):
     user.limits_private_thread_invites_to = user.LIMIT_INVITES_TO_FOLLOWED
     user.save()
 
     with pytest.raises(ValidationError) as exc_info:
-        validate_can_invite_user(
+        validate_new_private_thread_member(
             UserPermissionsProxy(user, cache_versions),
             UserPermissionsProxy(other_user, cache_versions),
             cache_versions,
@@ -94,27 +94,27 @@ def test_validate_can_invite_user_fails_for_user_who_limits_private_thread_invit
     ]
 
 
-def test_validate_can_invite_user_passes_followed_for_user_who_limits_private_thread_invites_to_followed(
+def test_validate_new_private_thread_member_passes_followed_for_user_who_limits_private_thread_invites_to_followed(
     user, other_user, cache_versions
 ):
     user.follows.add(other_user)
     user.limits_private_thread_invites_to = user.LIMIT_INVITES_TO_FOLLOWED
     user.save()
 
-    validate_can_invite_user(
+    validate_new_private_thread_member(
         UserPermissionsProxy(user, cache_versions),
         UserPermissionsProxy(other_user, cache_versions),
         cache_versions,
     )
 
 
-def test_validate_can_invite_user_passes_moderator_for_user_who_limits_private_thread_invites_to_followed(
+def test_validate_new_private_thread_member_passes_moderator_for_user_who_limits_private_thread_invites_to_followed(
     user, moderator, cache_versions
 ):
     user.limits_private_thread_invites_to = user.LIMIT_INVITES_TO_FOLLOWED
     user.save()
 
-    validate_can_invite_user(
+    validate_new_private_thread_member(
         UserPermissionsProxy(user, cache_versions),
         UserPermissionsProxy(moderator, cache_versions),
         cache_versions,


### PR DESCRIPTION
Adds missing plugin hook for `validate_new_private_thread_member`.

Part of the #1965 epic.