### PR TITLE
Handle empty avatar lists

### DIFF
--- a/misago/users/avatars/selection.py
+++ b/misago/users/avatars/selection.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+AvatarEntry = Mapping[str, Any]
+
+
+def _normalize_size(size: Any) -> int:
+    try:
+        return int(size)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_avatar_sequence(raw: Any) -> Sequence[AvatarEntry]:
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, tuple):
+        return list(raw)
+    return []
+
+
+def resolve_avatar_for_size(raw: Any, size: Any) -> Optional[AvatarEntry]:
+    """Return avatar entry closest to requested size or None when unavailable."""
+
+    avatars = _coerce_avatar_sequence(raw)
+    if not avatars:
+        return None
+
+    requested_size = _normalize_size(size)
+    selected: Optional[AvatarEntry] = None
+
+    for avatar in avatars:
+        if not isinstance(avatar, Mapping):
+            continue
+
+        url = avatar.get("url")
+        if not url:
+            continue
+
+        if selected is None:
+            selected = avatar
+
+        avatar_size = avatar.get("size")
+        if isinstance(avatar_size, int) and avatar_size >= requested_size:
+            selected = avatar
+
+    return selected

--- a/misago/users/templatetags/misago_avatars.py
+++ b/misago/users/templatetags/misago_avatars.py
@@ -1,12 +1,17 @@
 from django import template
+from django.templatetags.static import static
+
+from ...conf import settings
+from ..avatars.selection import resolve_avatar_for_size
 
 register = template.Library()
 
 
 @register.filter(name="avatar")
 def avatar(user, size=200):
-    found_avatar = user.avatars[0]
-    for user_avatar in user.avatars:
-        if user_avatar["size"] >= size:
-            found_avatar = user_avatar
+    avatars = getattr(user, "avatars", None) if user else None
+    found_avatar = resolve_avatar_for_size(avatars, size)
+    if not found_avatar:
+        return static(settings.MISAGO_BLANK_AVATAR)
+
     return found_avatar["url"]

--- a/misago/users/tests/test_avatar_filter.py
+++ b/misago/users/tests/test_avatar_filter.py
@@ -1,5 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.templatetags.static import static
 
+from ...conf import settings
 from ..templatetags.misago_avatars import avatar
 
 
@@ -22,3 +25,21 @@ def test_filter_returns_url_largest_image_if_requested_size_is_not_available(
     user, avatars
 ):
     assert avatar(user, 500) == avatars[400]
+
+
+def test_filter_returns_blank_avatar_if_user_has_no_avatars(user):
+    user.avatars = []
+
+    assert avatar(user) == static(settings.MISAGO_BLANK_AVATAR)
+
+
+def test_filter_returns_blank_avatar_for_missing_user():
+    assert avatar(None) == static(settings.MISAGO_BLANK_AVATAR)
+
+
+def test_filter_returns_blank_avatar_for_anonymous_user():
+    assert avatar(AnonymousUser()) == static(settings.MISAGO_BLANK_AVATAR)
+
+
+def test_filter_handles_string_size_argument(user, avatars):
+    assert avatar(user, "250") == avatars[400]

--- a/misago/users/tests/test_avatarserver_views.py
+++ b/misago/users/tests/test_avatarserver_views.py
@@ -41,6 +41,32 @@ class AvatarServerTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response["location"].endswith(settings.MISAGO_BLANK_AVATAR))
 
+    def test_get_user_avatar_returns_blank_when_user_has_no_avatars(self):
+        """avatar server falls back to blank avatar when user list is empty"""
+        self.user.avatars = []
+        self.user.save(update_fields=["avatars"])
+
+        avatar_url = reverse(
+            "misago:user-avatar", kwargs={"pk": self.user.pk, "size": 150}
+        )
+        response = self.client.get(avatar_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response["location"].endswith(settings.MISAGO_BLANK_AVATAR))
+
+    def test_get_user_avatar_returns_blank_when_user_has_none_in_db(self):
+        """avatar server falls back when avatars are None in the database"""
+        self.user.avatars = None
+        self.user.save(update_fields=["avatars"])
+
+        avatar_url = reverse(
+            "misago:user-avatar", kwargs={"pk": self.user.pk, "size": 100}
+        )
+        response = self.client.get(avatar_url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response["location"].endswith(settings.MISAGO_BLANK_AVATAR))
+
     def test_blank_avatar_serving(self):
         """avatar server handles blank avatar requests"""
         response = self.client.get(reverse("misago:blank-avatar"))

--- a/misago/users/views/avatarserver.py
+++ b/misago/users/views/avatarserver.py
@@ -3,6 +3,7 @@ from django.shortcuts import redirect
 from django.templatetags.static import static
 
 from ...conf import settings
+from ..avatars.selection import resolve_avatar_for_size
 
 User = get_user_model()
 
@@ -15,10 +16,10 @@ def user_avatar(request, pk, size):
     except User.DoesNotExist:
         return blank_avatar(request)
 
-    found_avatar = user.avatars[0]
-    for avatar in user.avatars:
-        if avatar["size"] >= size:
-            found_avatar = avatar
+    found_avatar = resolve_avatar_for_size(getattr(user, "avatars", None), size)
+    if not found_avatar:
+        return blank_avatar(request)
+
     return redirect(found_avatar["url"])
 
 


### PR DESCRIPTION
## Summary
- add misago/users/avatars/selection.py helper for choosing an avatar entry safely
- switch the avatar template filter and misago:user-avatar view to use that helper and fall back to MISAGO_BLANK_AVATAR when user.avatars is empty or None
- extend test_avatar_filter.py and test_avatarserver_views.py to cover empty/missing avatars, anonymous users, and string size inputs

Fixes #2016.

## Testing
- Manual: ran the Docker dev stack on main; homepage no longer 500s when user.avatars is empty; blank avatar returned correctly.