### PR TITLE
Fix Dockerfile best-practice violations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV IN_MISAGO_DOCKER 1
 ENV MISAGO_PLUGINS "/app/plugins"
 
 # Install env dependencies in one single command/layer
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install --no-install-recommends -y \
     vim \
     libffi-dev \
     libssl-dev \
@@ -18,23 +18,24 @@ RUN apt-get update && apt-get install -y \
     locales \
     cron \
     postgresql-client-15 \
-    gettext
+    gettext \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add files and dirs for build step
-ADD dev /app/dev
-ADD requirements.txt /app/requirements.txt
-ADD plugins /app/plugins
+COPY dev /app/dev
+COPY requirements.txt /app/requirements.txt
+COPY plugins /app/plugins
 
 WORKDIR /app/
 
 # Install Misago requirements
-RUN pip install --upgrade pip && \
-    pip install -r /app/requirements.txt && \
-    pip install pip-tools
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r /app/requirements.txt && \
+    pip install --no-cache-dir pip-tools
 
 # Bootstrap plugins
 RUN ./dev bootstrap_plugins
 
 EXPOSE 8000
 
-CMD python manage.py runserver 0.0.0.0:8000 --noreload
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000", "--noreload"]


### PR DESCRIPTION
## Summary

This PR addresses several Dockerfile best-practice violations:

- **`--no-install-recommends`**: Reduces image size by skipping unnecessary recommended packages
- **`rm -rf /var/lib/apt/lists/*`**: Cleans apt cache in the same layer to avoid bloating the image
- **`ADD` → `COPY`**: `COPY` is preferred when no tar extraction or URL fetching is needed ([Docker docs](https://docs.docker.com/build/building/best-practices/#add-or-copy))
- **`--no-cache-dir`**: Prevents pip from caching downloaded packages inside the image
- **Exec-form `CMD`**: Ensures the process receives OS signals (e.g., `SIGTERM`) correctly ([Docker docs](https://docs.docker.com/reference/dockerfile/#cmd))

All changes preserve the existing Dockerfile structure and behavior. No functional changes.

## Test plan

- [ ] `docker compose build` completes successfully
- [ ] `docker compose up` starts Misago dev server as before
- [ ] Verify image size is reduced compared to the current build