### PR TITLE
refactor: rename get_reply_*_state functions for consistency

### DIFF
--- a/misago/posting/state/__init__.py
+++ b/misago/posting/state/__init__.py
@@ -10,8 +10,8 @@ from .reply import (
     ReplyState,
     PrivateThreadReplyState,
     ThreadReplyState,
-    get_reply_private_thread_state,
-    get_reply_thread_state,
+    get_private_thread_reply_state,
+    get_thread_reply_state,
 )
 from .start import (
     PrivateThreadStartState,
@@ -35,7 +35,7 @@ __all__ = [
     "get_private_thread_post_edit_state",
     "get_thread_post_edit_state",
     "get_private_thread_start_state",
-    "get_reply_private_thread_state",
-    "get_reply_thread_state",
+    "get_private_thread_reply_state",
+    "get_thread_reply_state",
     "get_thread_start_state",
 ]

--- a/misago/posting/state/reply.py
+++ b/misago/posting/state/reply.py
@@ -123,29 +123,29 @@ class PrivateThreadReplyState(ReplyState):
         save_private_thread_reply_state_hook(self.save_action, self.request, self)
 
 
-def get_reply_thread_state(
+def get_thread_reply_state(
     request: HttpRequest, thread: Thread, post: Post | None = None
 ) -> ReplyState:
     return get_thread_reply_state_hook(
-        _get_reply_thread_state_action, request, thread, post
+        _get_thread_reply_state_action, request, thread, post
     )
 
 
-def _get_reply_thread_state_action(
+def _get_thread_reply_state_action(
     request: HttpRequest, thread: Thread, post: Post | None = None
 ) -> ReplyState:
     return ReplyState(request, thread, post)
 
 
-def get_reply_private_thread_state(
+def get_private_thread_reply_state(
     request: HttpRequest, thread: Thread, post: Post | None = None
 ) -> PrivateThreadReplyState:
     return get_private_thread_reply_state_hook(
-        _get_reply_private_thread_state_action, request, thread, post
+        _get_private_thread_reply_state_action, request, thread, post
     )
 
 
-def _get_reply_private_thread_state_action(
+def _get_private_thread_reply_state_action(
     request: HttpRequest, thread: Thread, post: Post | None = None
 ) -> PrivateThreadReplyState:
     return PrivateThreadReplyState(request, thread, post)

--- a/misago/posting/views/reply.py
+++ b/misago/posting/views/reply.py
@@ -53,8 +53,8 @@ from ..state import (
     PrivateThreadReplyState,
     ReplyState,
     ThreadReplyState,
-    get_reply_private_thread_state,
-    get_reply_thread_state,
+    get_private_thread_reply_state,
+    get_thread_reply_state,
 )
 from ..validators import validate_flood_control, validate_posted_contents
 
@@ -362,7 +362,7 @@ class ThreadReplyView(ReplyView, ThreadView):
     def get_state(
         self, request: HttpRequest, thread: Thread, post: Post | None
     ) -> ThreadReplyState:
-        return get_reply_thread_state(request, thread, post)
+        return get_thread_reply_state(request, thread, post)
 
     def get_formset(
         self, request: HttpRequest, thread: Thread, initial: dict | None = None
@@ -418,7 +418,7 @@ class PrivateThreadReplyView(ReplyView, PrivateThreadView):
     def get_state(
         self, request: HttpRequest, thread: Thread, post: Post | None
     ) -> PrivateThreadReplyState:
-        return get_reply_private_thread_state(request, thread, post)
+        return get_private_thread_reply_state(request, thread, post)
 
     def get_formset(
         self, request: HttpRequest, thread: Thread, initial: dict | None = None


### PR DESCRIPTION
Closes #2046

Renames the public and private helper functions to use consistent noun-first ordering, matching the existing hook names (`get_thread_reply_state_hook`, `get_private_thread_reply_state_hook`):

| Before | After |
|--------|-------|
| `get_reply_thread_state` | `get_thread_reply_state` |
| `get_reply_private_thread_state` | `get_private_thread_reply_state` |
| `_get_reply_thread_state_action` | `_get_thread_reply_state_action` |
| `_get_reply_private_thread_state_action` | `_get_private_thread_reply_state_action` |

All call sites in `misago/posting/views/reply.py` and `misago/posting/state/__init__.py` updated accordingly.