### PR TITLE
Add Helix-style Docker harness for full pytest with Postgres

### DIFF
--- a/.helix/Dockerfile.helix
+++ b/.helix/Dockerfile.helix
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1
+# BuildKit frontend: required so multi-line RUN + shell heredoc is one instruction (otherwise
+# lines like "from pathlib import ..." are misparsed as Dockerfile FROM).
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PIP_RESOLVER_BACKTRACKING_LIMIT=100
+
+# PostgreSQL server: Misago tests require Postgres (devproject/settings.py DATABASES).
+# Helix run-tests-eval.sh must not invoke Docker; DB runs in the same container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    libffi-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libpq-dev \
+    libssl-dev \
+    libyaml-dev \
+    zlib1g-dev \
+    postgresql \
+    && rm -rf /var/lib/apt/lists/*
+
+# Entrypoint starts Postgres, then runs CMD (pytest or ./.helix/run-tests-eval.sh).
+# Written here so .helix/ stays limited to the three required Helix files.
+RUN python3 << 'PY'
+import pathlib
+pathlib.Path("/usr/local/bin/helix-entrypoint.sh").write_text(
+    r'''#!/bin/bash
+set -euo pipefail
+
+PG_BIN=""
+for d in /usr/lib/postgresql/*/bin; do
+  [[ -x "$d/initdb" ]] && PG_BIN="$d" && break
+done
+if [[ -z "$PG_BIN" || ! -x "$PG_BIN/initdb" ]]; then
+  echo "helix-entrypoint: PostgreSQL binaries not found under /usr/lib/postgresql" >&2
+  exit 1
+fi
+
+PGDATA="${PGDATA:-/var/lib/postgresql/helix-data}"
+export PGDATA
+mkdir -p "$PGDATA"
+chown -R postgres:postgres "$PGDATA"
+
+if [[ ! -f "$PGDATA/PG_VERSION" ]]; then
+  runuser -u postgres -- "$PG_BIN/initdb" -D "$PGDATA" --encoding=UTF8 --locale=C -A trust
+  echo "listen_addresses = '127.0.0.1'" >> "$PGDATA/postgresql.conf"
+  echo "host all all 127.0.0.1/32 trust" >> "$PGDATA/pg_hba.conf"
+fi
+
+# Idempotent: run-tests-eval may invoke pytest only after Docker ENTRYPOINT already started Postgres.
+runuser -u postgres -- "$PG_BIN/pg_ctl" -D "$PGDATA" -w -l /tmp/postgres.log start || true
+
+ready=0
+for _ in $(seq 1 120); do
+  if runuser -u postgres -- "$PG_BIN/pg_isready" -h 127.0.0.1 -p 5432; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$ready" -ne 1 ]]; then
+  echo "helix-entrypoint: PostgreSQL did not become ready in time" >&2
+  exit 1
+fi
+
+runuser -u postgres -- "$PG_BIN/psql" -d postgres -v ON_ERROR_STOP=1 -tc \
+  "SELECT 1 FROM pg_roles WHERE rolname='misago'" | grep -q 1 \
+  || runuser -u postgres -- "$PG_BIN/psql" -d postgres -v ON_ERROR_STOP=1 -c \
+     "CREATE USER misago WITH PASSWORD 'misago' SUPERUSER CREATEDB;"
+
+runuser -u postgres -- "$PG_BIN/psql" -d postgres -tc \
+  "SELECT 1 FROM pg_database WHERE datname='misago'" | grep -q 1 \
+  || runuser -u postgres -- "$PG_BIN/psql" -d postgres -c "CREATE DATABASE misago OWNER misago;"
+
+export POSTGRES_HOST=127.0.0.1
+export POSTGRES_DB=misago
+export POSTGRES_USER=misago
+export POSTGRES_PASSWORD=misago
+export POSTGRES_TEST_DB=misago_test
+
+# devproject/settings.py: PLUGINS_DIRECTORY = os.environ.get("MISAGO_PLUGINS")
+# Without this, discover_plugins returns [] and plugin tests fail (empty INSTALLED_PLUGINS).
+export MISAGO_PLUGINS=/app/plugins
+
+exec "$@"
+''',
+    encoding="utf-8",
+)
+import os
+os.chmod("/usr/local/bin/helix-entrypoint.sh", 0o755)
+PY
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# helix: pytest may be missing when dev extras are not installed
+RUN python3 -m pip install --no-cache-dir pytest
+
+ENTRYPOINT ["/usr/local/bin/helix-entrypoint.sh"]
+# pytest.ini sets testpaths = misago (no repo-root tests/ directory)
+CMD ["pytest"]

--- a/.helix/run-tests-eval.sh
+++ b/.helix/run-tests-eval.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+DOCKERFILE="$SCRIPT_DIR/Dockerfile.helix"
+
+die()  { echo "Error: $*" >&2; exit 1; }
+info() { echo "$*" >&2; }
+
+# ── Parse test command from Dockerfile.helix (CMD or ENTRYPOINT) ──
+
+parse_instruction() {
+    local raw="$1"
+    if [[ "$raw" == \[* ]]; then
+        local inner="${raw#\[}"
+        inner="${inner%\]}"
+        local result="" elem=""
+        while IFS= read -r -d ',' elem || [[ -n "$elem" ]]; do
+            elem=$(echo "$elem" | sed 's/^[[:space:]]*"//; s/"[[:space:]]*$//')
+            [[ -z "$elem" ]] && continue
+            if [[ "$elem" == *" "* ]]; then
+                elem="${elem//\\/\\\\}"
+                elem="${elem//\"/\\\"}"
+                result+="\"${elem}\" "
+            else
+                result+="$elem "
+            fi
+        done <<< "$inner"
+        echo "$result" | sed 's/ *$//'
+    else
+        echo "$raw"
+    fi
+}
+
+extract_cmd() {
+    local cmd_line="" ep_line=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        local trimmed="${line#"${line%%[![:space:]]*}"}"
+        case "${trimmed}" in
+            CMD\ *|cmd\ *)
+                cmd_line="${trimmed:4}"; cmd_line="${cmd_line#"${cmd_line%%[![:space:]]*}"}" ;;
+            ENTRYPOINT\ *|entrypoint\ *)
+                ep_line="${trimmed:11}"; ep_line="${ep_line#"${ep_line%%[![:space:]]*}"}" ;;
+        esac
+    done < "$DOCKERFILE"
+
+    if [[ -n "$cmd_line" ]]; then
+        local cmd; cmd=$(parse_instruction "$cmd_line")
+        if [[ -n "$ep_line" ]]; then
+            local ep; ep=$(parse_instruction "$ep_line")
+            # Docker already ran ENTRYPOINT before this script; CMD is the real test command.
+            # Combining ENTRYPOINT+CMD would run the Postgres bootstrap twice and break (set -e / pg_ctl).
+            if [[ "$ep" == "/usr/local/bin/helix-entrypoint.sh" ]]; then
+                echo "$cmd"
+            else
+                echo "${ep} ${cmd}"
+            fi
+        else
+            echo "$cmd"
+        fi
+    elif [[ -n "$ep_line" ]]; then
+        parse_instruction "$ep_line"
+    else
+        die "No CMD or ENTRYPOINT found in $DOCKERFILE"
+    fi
+}
+
+# ── Resolve yarn/npm/pnpm script aliases ─────────────────────────
+
+resolve_script() {
+    local cmd="$1" script_name=""
+
+    if [[ "$cmd" =~ ^(yarn|pnpm)[[:space:]]+([a-zA-Z][^[:space:]]*) ]]; then
+        script_name="${BASH_REMATCH[2]}"
+    elif [[ "$cmd" =~ ^(npm|pnpm)[[:space:]]+run[[:space:]]+([^[:space:]]+) ]]; then
+        script_name="${BASH_REMATCH[2]}"
+    elif [[ "$cmd" =~ ^npm[[:space:]]+test ]]; then
+        script_name="test"
+    fi
+
+    if [[ -z "$script_name" ]]; then echo "$cmd"; return; fi
+    if [[ ! -f "package.json" ]]; then echo "$cmd"; return; fi
+
+    local resolved=""
+    if command -v node &>/dev/null; then
+        resolved=$(node -e "
+            try { console.log(require('./package.json').scripts['$script_name'] || '') }
+            catch(e) { console.log('') }
+        " 2>/dev/null) || true
+    elif command -v python3 &>/dev/null; then
+        resolved=$(python3 -c "
+import json
+print(json.load(open('package.json')).get('scripts',{}).get('$script_name',''))
+" 2>/dev/null) || true
+    fi
+
+    [[ -n "$resolved" ]] && echo "$resolved" || echo "$cmd"
+}
+
+# ── Detect the underlying test runner ─────────────────────────────
+
+detect_runner() {
+    local cmd="$1"
+    case "$cmd" in
+        pytest*|*" pytest "*|python*-m*pytest*)   echo "pytest" ;;
+        *vitest*)                                  echo "vitest" ;;
+        *jest*)                                    echo "jest" ;;
+        *mocha*)                                   echo "mocha" ;;
+        go\ test*)                                 echo "go" ;;
+        cargo\ test*|cargo\ nextest*)              echo "cargo" ;;
+        mvn\ *|./mvnw\ *)                         echo "maven" ;;
+        *gradle*test*|*gradlew*test*)              echo "gradle" ;;
+        *rspec*)                                   echo "rspec" ;;
+        *phpunit*)                                 echo "phpunit" ;;
+        dotnet\ test*)                             echo "dotnet" ;;
+        mix\ test*)                                echo "mix" ;;
+        swift\ test*)                              echo "swift" ;;
+        sbt*test*)                                 echo "sbt" ;;
+        *nose2*)                                   echo "nose2" ;;
+        ruby*-I*|ruby*test*|rake\ test*)           echo "ruby" ;;
+        *ctest*|*" ctest "*)                       echo "ctest" ;;
+        meson\ test*|*"meson test"*)               echo "meson" ;;
+        *)                                         echo "unknown" ;;
+    esac
+}
+
+# ── Strip coverage flags (prevent coverage gates from failing eval) ──
+
+strip_coverage_flags() {
+    local runner="$1" cmd="$2"
+    case "$runner" in
+        pytest)   cmd=$(echo "$cmd" | sed -E 's/ --cov[=-][^ ]*//g; s/ --cov\b//g; s/ --no-cov-on-fail//g') ;;
+        jest|vitest) cmd=$(echo "$cmd" | sed -E 's/ --coverage[^ ]*//g') ;;
+        go)       cmd=$(echo "$cmd" | sed -E 's/ -cover\b//g; s/ -coverprofile[= ][^ ]*//g; s/ -coverpkg[= ][^ ]*//g') ;;
+        phpunit)  cmd=$(echo "$cmd" | sed -E 's/ --coverage-[^ ]*//g') ;;
+        mix)      cmd=$(echo "$cmd" | sed -E 's/ --cover\b//g') ;;
+        dotnet)   cmd=$(echo "$cmd" | sed -E 's/ --collect:[^ ]*//g; s| /p:CollectCoverage=[^ ]*||g; s| /p:Threshold=[^ ]*||g') ;;
+    esac
+    echo "$cmd"
+}
+
+# ── JVM: convert file path to fully-qualified class name ──────────
+
+path_to_classname() {
+    local f="$1"
+    for prefix in src/test/java/ src/test/kotlin/ src/test/scala/ \
+                  src/main/java/ src/main/kotlin/ src/main/scala/ \
+                  src/it/java/ src/it/kotlin/ src/it/scala/; do
+        f="${f#$prefix}"
+    done
+    for ext in .java .kt .scala .groovy .kts; do
+        f="${f%$ext}"
+    done
+    echo "${f//\//.}"
+}
+
+# ── Construct the test command for a specific set of files ────────
+
+build_targeted_cmd() {
+    local runner="$1" full_cmd="$2"
+    shift 2
+    local files=("$@")
+
+    case "$runner" in
+        pytest)   echo "pytest ${files[*]}" ;;
+        vitest)   echo "vitest run ${files[*]}" ;;
+        jest)     echo "npx jest --watchAll=false ${files[*]}" ;;
+        mocha)    echo "npx mocha ${files[*]}" ;;
+        nose2)    echo "nose2 ${files[*]}" ;;
+        mix)      echo "mix test ${files[*]}" ;;
+        ruby)     echo "ruby ${files[*]}" ;;
+        rspec)
+            if command -v bundle &>/dev/null; then
+                echo "bundle exec rspec ${files[*]}"
+            else
+                echo "rspec ${files[*]}"
+            fi
+            ;;
+        phpunit)
+            if [[ -f "./vendor/bin/phpunit" ]]; then
+                echo "./vendor/bin/phpunit ${files[*]}"
+            else
+                echo "phpunit ${files[*]}"
+            fi
+            ;;
+        go)
+            declare -A _go_dirs=()
+            for f in "${files[@]}"; do
+                _go_dirs["./$(dirname "$f")"]=1
+            done
+            echo "go test ${!_go_dirs[*]}"
+            ;;
+        cargo)
+            local is_workspace=0
+            if [[ -f "Cargo.toml" ]] && grep -q '^\[workspace\]' "Cargo.toml" 2>/dev/null; then
+                is_workspace=1
+            fi
+
+            # Preserve the base command with all its flags (--features, --release, etc.)
+            # by stripping only the trailing "-- <args>" portion.
+            local base_cmd
+            base_cmd="$(echo "$full_cmd" | sed 's/[[:space:]]\+--[[:space:]]\+.*$//')"
+
+            declare -A _cargo_seen=()
+            local cmds=()
+            for f in "${files[@]}"; do
+                local pkg="" pkg_dir=""
+                if (( is_workspace )); then
+                    local d
+                    d="$(dirname "$f")"
+                    while [[ -n "$d" && "$d" != "." ]]; do
+                        if [[ -f "$d/Cargo.toml" ]] && grep -q '^\[package\]' "$d/Cargo.toml" 2>/dev/null; then
+                            pkg=$(sed -n '/^\[package\]/,/^\[/{s/^name[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p;}' "$d/Cargo.toml" 2>/dev/null | head -1)
+                            pkg_dir="$d"
+                            break
+                        fi
+                        d="$(dirname "$d")"
+                    done
+                fi
+                local rel="$f"
+                [[ -n "$pkg_dir" ]] && rel="${f#$pkg_dir/}"
+                local flag=""
+                if [[ "$rel" == tests/* ]]; then
+                    flag="--test $(basename "$f" .rs)"
+                else
+                    flag="--lib"
+                fi
+                local key="${pkg:-__root__}::${flag}"
+                if [[ -z "${_cargo_seen[$key]:-}" ]]; then
+                    _cargo_seen["$key"]=1
+                    local pfx=""
+                    [[ -n "$pkg" ]] && pfx="-p $pkg "
+                    cmds+=("${base_cmd} ${pfx}${flag}")
+                fi
+            done
+            local result=""
+            for ((i=0; i<${#cmds[@]}; i++)); do
+                (( i > 0 )) && result+=" && "
+                result+="${cmds[$i]}"
+            done
+            echo "$result"
+            ;;
+        maven)
+            local classes=()
+            for f in "${files[@]}"; do classes+=("$(path_to_classname "$f")"); done
+            local joined; joined="$(IFS=,; echo "${classes[*]}")"
+            [[ -f "./mvnw" ]] && echo "./mvnw test -Dtest=${joined}" || echo "mvn test -Dtest=${joined}"
+            ;;
+        gradle)
+            local args=""
+            for f in "${files[@]}"; do args+=" --tests $(path_to_classname "$f")"; done
+            [[ -f "./gradlew" ]] && echo "./gradlew test${args}" || echo "gradle test${args}"
+            ;;
+        dotnet)
+            local parts=()
+            for f in "${files[@]}"; do parts+=("FullyQualifiedName~$(basename "$f" .cs)"); done
+            local filter; filter="$(IFS='|'; echo "${parts[*]}")"
+            echo "dotnet test --filter \"${filter}\""
+            ;;
+        swift)
+            local names=()
+            for f in "${files[@]}"; do names+=("$(basename "$f" .swift)"); done
+            local joined; joined="$(IFS=,; echo "${names[*]}")"
+            echo "swift test --filter ${joined}"
+            ;;
+        sbt)
+            local names=()
+            for f in "${files[@]}"; do names+=("$(path_to_classname "$f")"); done
+            echo "sbt 'testOnly ${names[*]}'"
+            ;;
+        ctest)
+            # Subset by CTest regex (-R): join basenames (strip common source extensions).
+            local rx="" b f
+            for f in "${files[@]}"; do
+                b=$(basename "$f")
+                b="${b%.cpp}"; b="${b%.cc}"; b="${b%.cxx}"; b="${b%.c}"; b="${b%.hpp}"
+                [[ -n "$rx" ]] && rx+="|"
+                rx+="$b"
+            done
+            if [[ "$full_cmd" =~ ^[[:space:]]*ctest(.*)$ ]]; then
+                echo "ctest -R $(printf '%q' "$rx")${BASH_REMATCH[1]}"
+            else
+                echo "ctest -R $(printf '%q' "$rx") --test-dir build --output-on-failure"
+            fi
+            ;;
+        meson)
+            # Best-effort: meson test accepts test names as positional args (project-defined).
+            local names=()
+            for f in "${files[@]}"; do names+=("$(basename "$f" .cpp)"); done
+            echo "meson test -C builddir --print-errorlogs ${names[*]}"
+            ;;
+        *)
+            info "Warning: unknown runner — appending files to original command"
+            echo "${full_cmd} ${files[*]}"
+            ;;
+    esac
+}
+
+# ── Normalize stale pytest paths (Helix compat) ───────────────────
+#
+# The image may be built from an outer Dockerfile that embeds Postgres, but
+# `COPY . .` restores the branch's `.helix/Dockerfile.helix`. On existing-solution
+# that file still says `pytest tests/` even though this repo has no repo-root
+# `tests/` (pytest.ini uses testpaths = misago). Eval would then fail with
+# "file or directory not found: tests/".
+normalize_pytest_cmd_for_repo_layout() {
+    [[ -d "tests" ]] && return 0
+    if [[ "$FULL_CMD" =~ pytest[[:space:]]+tests/ ]] || [[ "$RESOLVED" =~ pytest[[:space:]]+tests/ ]]; then
+        FULL_CMD="pytest"
+        RESOLVED="pytest"
+        RUNNER="pytest"
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────
+
+[[ ! -f "$DOCKERFILE" ]] && die "$DOCKERFILE not found in $(pwd)"
+
+FULL_CMD=$(extract_cmd)
+RESOLVED=$(resolve_script "$FULL_CMD")
+RUNNER=$(detect_runner "$RESOLVED")
+normalize_pytest_cmd_for_repo_layout
+
+if [[ $# -eq 0 || -z "${1:-}" ]]; then
+    FULL_CMD=$(strip_coverage_flags "$RUNNER" "$FULL_CMD")
+    info "=== Full test suite ==="
+    info "Command: $FULL_CMD"
+    info "========================"
+    eval "$FULL_CMD"
+else
+    IFS=',' read -ra TEST_FILES <<< "$1"
+
+    TARGETED=$(build_targeted_cmd "$RUNNER" "$FULL_CMD" "${TEST_FILES[@]}")
+    TARGETED=$(strip_coverage_flags "$RUNNER" "$TARGETED")
+
+    info "=== Targeted tests ==="
+    info "Runner:  $RUNNER"
+    info "Files:   ${TEST_FILES[*]}"
+    info "Command: $TARGETED"
+    info "========================"
+    eval "$TARGETED"
+fi


### PR DESCRIPTION
## Summary
Adds a small `.helix/` layout for environments that build one Docker image and run the full Python test suite without an external PostgreSQL service.

## Contents
- **`.helix/Dockerfile.helix`**: `python:3.12-slim` base, installs PostgreSQL and project deps, embeds an entrypoint that initializes DB + `POSTGRES_*` env vars (`devproject` settings), sets `MISAGO_PLUGINS=/app/plugins` so plugin discovery matches a normal dev tree, default `CMD` is `pytest` (`pytest.ini` `testpaths = misago`).
- **`.helix/run-tests-eval.sh`**: Reads `CMD`/`ENTRYPOINT` from `Dockerfile.helix`; when the entrypoint is `/usr/local/bin/helix-entrypoint.sh`, runs only the test command so Postgres is not bootstrapped twice. Normalizes stale `pytest tests/` invocations when no repo-root `tests/` exists (compat with older Helix metadata copied into the image).

## Usage (local)
```bash
docker build -f .helix/Dockerfile.helix -t misago-tests .
docker run --rm misago-tests
# or
docker run --rm misago-tests ./.helix/run-tests-eval.sh
```

## Note
This does not change application code or existing `docker-compose` workflows; it only adds optional CI/evaluator-oriented files under `.helix/`.

Made with [Cursor](https://cursor.com)