### PR TITLE
Refactor category synchronization

### DIFF
--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -45,6 +45,7 @@ Hooks instances are importable from the following Python modules:
 - [`get_categories_page_metatags_hook`](./get-categories-page-metatags-hook.md)
 - [`get_categories_query_values_hook`](./get-categories-query-values-hook.md)
 - [`get_category_data_hook`](./get-category-data-hook.md)
+- [`synchronize_category_hook`](./synchronize-category-hook.md)
 
 
 ## `misago.context_processors.hooks`

--- a/dev-docs/plugins/hooks/synchronize-category-hook.md
+++ b/dev-docs/plugins/hooks/synchronize-category-hook.md
@@ -1,0 +1,117 @@
+# `synchronize_category_hook`
+
+This hook allows plugins to replace or extend the logic used to synchronize categories.
+
+Category synchronization updates a category’s thread and post counts, as well as its last thread activity.
+
+
+## Location
+
+This hook can be imported from `misago.categories.hooks`:
+
+```python
+from misago.categories.hooks import synchronize_category_hook
+```
+
+
+## Filter
+
+```python
+def custom_synchronize_category_filter(
+    action: SynchronizeCategoryHookAction,
+    category: Category,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> None:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: SynchronizeCategoryHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `category: Category`
+
+The category to synchronize.
+
+
+#### `commit: bool`
+
+Whether the updated category instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+## Action
+
+```python
+def synchronize_category_action(
+    category: Category,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> None:
+    ...
+```
+
+Misago function for synchronizing a category.
+
+
+### Arguments
+
+#### `category: Category`
+
+The category to synchronize.
+
+
+#### `commit: bool`
+
+Whether the updated category instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+## Example
+
+Record the last user who synchronized the category:
+
+```python
+from django.http import HttpRequest
+from misago.categories.hooks import synchronize_category_hook
+from misago.categories.models import Category
+
+
+@synchronize_category_hook.append_filter
+def record_user_who_synced_category(
+    action,
+    category: Category,
+    commit: bool = True,
+    request: HttpRequest | None = None,
+):
+    if request:
+        data.plugin_data["last_synchronized"] = {
+            "user_id": request.user.id,
+            "user_ip": request.user_ip,
+        }
+    else:
+        data.plugin_data["last_synchronized"] = None
+
+    action(category, commit, request)
+```

--- a/misago/categories/delete.py
+++ b/misago/categories/delete.py
@@ -21,6 +21,7 @@ from ..threads.models import (
 from ..threadupdates.models import ThreadUpdate
 from .hooks import delete_categories_hook
 from .models import Category
+from .synchronize import synchronize_category
 
 __all__ = ["delete_category"]
 
@@ -127,8 +128,7 @@ def _move_categories_contents(categories: list[Category], new_category: Category
     # misago.threadupdates
     _move_objects(ThreadUpdate, categories, new_category)
 
-    new_category.synchronize()
-    new_category.save()
+    synchronize_category(new_category)
 
 
 def _move_objects(

--- a/misago/categories/hooks/__init__.py
+++ b/misago/categories/hooks/__init__.py
@@ -3,6 +3,7 @@ from .get_categories_page_component import get_categories_page_component_hook
 from .get_categories_page_metatags import get_categories_page_metatags_hook
 from .get_categories_query_values import get_categories_query_values_hook
 from .get_category_data import get_category_data_hook
+from .synchronize_category import synchronize_category_hook
 
 __all__ = [
     "delete_categories_hook",
@@ -10,4 +11,5 @@ __all__ = [
     "get_categories_page_metatags_hook",
     "get_categories_query_values_hook",
     "get_category_data_hook",
+    "synchronize_category_hook",
 ]

--- a/misago/categories/hooks/synchronize_category.py
+++ b/misago/categories/hooks/synchronize_category.py
@@ -1,0 +1,134 @@
+from typing import Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ..models import Category
+
+
+class SynchronizeCategoryHookAction(Protocol):
+    """
+    Misago function for synchronizing a category.
+
+    # Arguments
+
+    ## `category: Category`
+
+    The category to synchronize.
+
+    ## `commit: bool`
+
+    Whether the updated category instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+    """
+
+    def __call__(
+        self,
+        category: Category,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> None: ...
+
+
+class SynchronizeCategoryHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: SynchronizeCategoryHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `category: Category`
+
+    The category to synchronize.
+
+    ## `commit: bool`
+
+    Whether the updated category instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+    """
+
+    def __call__(
+        self,
+        action: SynchronizeCategoryHookAction,
+        category: Category,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> None: ...
+
+
+class SynchronizeCategoryHook(
+    FilterHook[
+        SynchronizeCategoryHookAction,
+        SynchronizeCategoryHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the logic used to
+    synchronize categories.
+
+    Category synchronization updates a category’s thread and post counts,
+    as well as its last thread activity.
+
+    # Example
+
+    Record the last user who synchronized the category:
+
+    ```python
+    from django.http import HttpRequest
+    from misago.categories.hooks import synchronize_category_hook
+    from misago.categories.models import Category
+
+
+    @synchronize_category_hook.append_filter
+    def record_user_who_synced_category(
+        action,
+        category: Category,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ):
+        if request:
+            data.plugin_data["last_synchronized"] = {
+                "user_id": request.user.id,
+                "user_ip": request.user_ip,
+            }
+        else:
+            data.plugin_data["last_synchronized"] = None
+
+        action(category, commit, request)
+    ```
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: SynchronizeCategoryHookAction,
+        category: Category,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> None:
+        return super().__call__(
+            action,
+            category,
+            commit,
+            request,
+        )
+
+
+synchronize_category_hook = SynchronizeCategoryHook()

--- a/misago/categories/management/commands/prunecategories.py
+++ b/misago/categories/management/commands/prunecategories.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from ....threads.move import move_threads
 from ...models import Category
+from ...synchronize import synchronize_category
 
 
 class Command(BaseCommand):
@@ -58,8 +59,7 @@ class Command(BaseCommand):
                     synchronize_categories.append(archive)
 
         for category in synchronize_categories:
-            category.synchronize()
-            category.save()
+            synchronize_category(category)
 
         self.stdout.write(f"\n\nPruned categories: {len(pruned_categories)}")
         if pruned_categories:

--- a/misago/categories/management/commands/synchronizecategories.py
+++ b/misago/categories/management/commands/synchronizecategories.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 
 from ....core.management.progressbar import show_progress
 from ...models import Category
+from ...synchronize import synchronize_category
 
 
 class Command(BaseCommand):
@@ -22,8 +23,7 @@ class Command(BaseCommand):
         synchronized_count = 0
         show_progress(self, synchronized_count, categories_to_sync)
         for category in Category.objects.iterator():
-            category.synchronize()
-            category.save()
+            synchronize_category(category)
 
             synchronized_count += 1
             show_progress(self, synchronized_count, categories_to_sync)

--- a/misago/categories/models.py
+++ b/misago/categories/models.py
@@ -103,25 +103,6 @@ class Category(MPTTModel, PluginDataModel):
         clear_acl_cache()
         return super().delete(*args, **kwargs)
 
-    def synchronize(self):
-        threads_queryset = self.thread_set.filter(is_hidden=False, is_unapproved=False)
-        self.threads = threads_queryset.count()
-
-        if self.threads:
-            replies_sum = threads_queryset.aggregate(models.Sum("replies"))
-            self.posts = self.threads + replies_sum["replies__sum"]
-        else:
-            self.posts = 0
-
-        if self.threads:
-            last_thread_qs = threads_queryset.filter(
-                is_hidden=False, is_unapproved=False
-            )
-            last_thread = last_thread_qs.order_by("-last_posted_at")[:1][0]
-            self.set_last_thread(last_thread)
-        else:
-            self.empty_last_thread()
-
     def get_absolute_url(self):
         return self.thread_type.get_category_absolute_url(self)
 

--- a/misago/categories/synchronize.py
+++ b/misago/categories/synchronize.py
@@ -1,0 +1,59 @@
+from django.http import HttpRequest
+
+from ..threads.models import Post, Thread
+from .hooks import synchronize_category_hook
+from .models import Category
+
+
+def synchronize_category(
+    category: Category, commit: bool = True, request: HttpRequest | None = None
+):
+    synchronize_category_hook(_synchronize_category_action, category, commit, request)
+
+
+def _synchronize_category_action(
+    category: Category, commit: bool = True, request: HttpRequest | None = None
+):
+    category.threads = Thread.objects.filter(
+        category=category, is_hidden=False, is_unapproved=False
+    ).count()
+
+    category.posts = Post.objects.filter(
+        category=category,
+        is_unapproved=False,
+        thread__is_hidden=False,
+        thread__is_unapproved=False,
+    ).count()
+
+    category.unapproved_threads = Thread.objects.filter(
+        category=category, is_unapproved=True
+    ).count()
+    category.unapproved_posts = Post.objects.filter(
+        category=category, is_unapproved=True
+    ).count()
+
+    last_thread = (
+        Thread.objects.filter(category=category, is_hidden=False, is_unapproved=False)
+        .order_by("last_post_id")
+        .last()
+    )
+
+    if last_thread:
+        category.last_posted_at = last_thread.last_posted_at
+        category.last_thread = last_thread
+        category.last_thread_title = last_thread.title
+        category.last_thread_slug = last_thread.slug
+        category.last_poster_id = last_thread.last_poster_id
+        category.last_poster_name = last_thread.last_poster_name
+        category.last_poster_slug = last_thread.last_poster_slug
+    else:
+        category.last_posted_at = None
+        category.last_thread = None
+        category.last_thread_title = None
+        category.last_thread_slug = None
+        category.last_poster = None
+        category.last_poster_name = None
+        category.last_poster_slug = None
+
+    if commit:
+        category.save()

--- a/misago/categories/tasks.py
+++ b/misago/categories/tasks.py
@@ -1,0 +1,10 @@
+from celery import shared_task
+
+from .models import Category
+from .synchronize import synchronize_category
+
+
+@shared_task(name="categories.synchronize", serializer="json")
+def synchronize_categories(category_ids: list[int]):
+    for category in Category.objects.filter(id__in=category_ids):
+        synchronize_category(category)

--- a/misago/categories/tests/test_categories_view.py
+++ b/misago/categories/tests/test_categories_view.py
@@ -10,6 +10,7 @@ from ...testutils import (
     remove_category_group_permissions,
 )
 from ..models import Category
+from ..synchronize import synchronize_category
 
 
 @override_dynamic_settings(index_view="threads")
@@ -167,8 +168,7 @@ def test_categories_view_displays_category_user_thread(
     default_category, user_client, user_thread
 ):
     default_category.description = "FIRST-CATEGORY-DESCRIPTION"
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(reverse("misago:categories"))
     assert_contains(response, default_category.description)
@@ -180,8 +180,7 @@ def test_categories_view_displays_category_thread(
     default_category, user_client, thread
 ):
     default_category.description = "FIRST-CATEGORY-DESCRIPTION"
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(reverse("misago:categories"))
     assert_contains(response, default_category.description)
@@ -196,8 +195,7 @@ def test_categories_view_displays_unread_category(
     user.save()
 
     default_category.description = "FIRST-CATEGORY-DESCRIPTION"
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(reverse("misago:categories"))
     assert_contains(response, default_category.description)
@@ -211,8 +209,7 @@ def test_categories_view_displays_category_thread_if_category_allows_list_access
 ):
     default_category.delay_browse_check = True
     default_category.description = "FIRST-CATEGORY-DESCRIPTION"
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     remove_category_group_permissions(default_category, user.group)
 
@@ -232,8 +229,7 @@ def test_categories_view_excludes_category_thread_if_user_has_no_browse_permissi
     default_category, user, user_client, thread
 ):
     default_category.description = "FIRST-CATEGORY-DESCRIPTION"
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     remove_category_group_permissions(default_category, user.group)
 

--- a/misago/categories/tests/test_category_model.py
+++ b/misago/categories/tests/test_category_model.py
@@ -1,4 +1,5 @@
 from ..models import Category
+from ..synchronize import synchronize_category
 
 
 def assert_category_is_empty(category: Category):
@@ -11,53 +12,10 @@ def assert_category_is_empty(category: Category):
     assert category.last_poster_slug is None
 
 
-def test_category_synchronize_updates_category_data(thread_factory, default_category):
-    default_category.synchronize()
-
-    assert default_category.threads == 0
-    assert default_category.posts == 0
-
-    thread = thread_factory(default_category)
-    hidden = thread_factory(default_category)
-    unapproved = thread_factory(default_category)
-
-    default_category.synchronize()
-    assert default_category.threads == 3
-    assert default_category.posts == 3
-    assert default_category.last_thread == unapproved
-
-    unapproved.is_unapproved = True
-    unapproved.post_set.update(is_unapproved=True)
-    unapproved.save()
-
-    default_category.synchronize()
-    assert default_category.threads == 2
-    assert default_category.posts == 2
-    assert default_category.last_thread == hidden
-
-    hidden.is_hidden = True
-    hidden.post_set.update(is_hidden=True)
-    hidden.save()
-
-    default_category.synchronize()
-    assert default_category.threads == 1
-    assert default_category.posts == 1
-    assert default_category.last_thread == thread
-
-    unapproved.is_unapproved = False
-    unapproved.post_set.update(is_unapproved=False)
-    unapproved.save()
-
-    default_category.synchronize()
-    assert default_category.threads == 2
-    assert default_category.posts == 2
-    assert default_category.last_thread == unapproved
-
-
 def test_category_set_last_thread_updates_last_thread_data(
     thread_factory, default_category
 ):
-    default_category.synchronize()
+    synchronize_category(default_category)
 
     new_thread = thread_factory(default_category)
     default_category.set_last_thread(new_thread)
@@ -76,7 +34,7 @@ def test_category_empty_last_thread_empties_last_thread_data(
 ):
     thread_factory(default_category)
 
-    default_category.synchronize()
+    synchronize_category(default_category)
     default_category.empty_last_thread()
 
     assert_category_is_empty(default_category)

--- a/misago/categories/tests/test_synchronize_categories_task.py
+++ b/misago/categories/tests/test_synchronize_categories_task.py
@@ -1,0 +1,19 @@
+from ..tasks import synchronize_categories
+
+
+def test_synchronize_categories_task_synchronizes_threads(
+    thread_factory, default_category, sibling_category
+):
+    thread_factory(default_category)
+    thread_factory(default_category)
+    thread_factory(default_category)
+    thread_factory(sibling_category)
+    thread_factory(sibling_category)
+
+    synchronize_categories([default_category.id, sibling_category.id])
+
+    default_category.refresh_from_db()
+    assert default_category.threads == 3
+
+    sibling_category.refresh_from_db()
+    assert sibling_category.threads == 2

--- a/misago/categories/tests/test_synchronize_category.py
+++ b/misago/categories/tests/test_synchronize_category.py
@@ -1,0 +1,129 @@
+from django.utils import timezone
+
+from ..synchronize import synchronize_category
+
+
+def test_synchronize_category_updates_threads(thread_factory, default_category):
+    thread_a = thread_factory(default_category)
+    thread_b = thread_factory(default_category)
+    thread_c = thread_factory(default_category, is_hidden=True)
+    thread_d = thread_factory(default_category, is_unapproved=True)
+
+    synchronize_category(default_category)
+
+    assert default_category.threads == 2
+    assert default_category.unapproved_threads == 1
+
+
+def test_synchronize_category_updates_posts(
+    thread_factory, thread_reply_factory, default_category
+):
+    thread_a = thread_factory(default_category)
+    thread_b = thread_factory(default_category)
+    thread_c = thread_factory(default_category, is_hidden=True)
+    thread_d = thread_factory(default_category, is_unapproved=True)
+
+    thread_reply_factory(thread_a)
+    thread_reply_factory(thread_a, is_hidden=True)
+    thread_reply_factory(thread_a, is_unapproved=True)
+    thread_reply_factory(thread_b)
+    thread_reply_factory(thread_b, is_hidden=True)
+    thread_reply_factory(thread_b, is_unapproved=True)
+    thread_reply_factory(thread_c)
+    thread_reply_factory(thread_c, is_hidden=True)
+    thread_reply_factory(thread_c, is_unapproved=True)
+    thread_reply_factory(thread_d)
+    thread_reply_factory(thread_d, is_hidden=True)
+    thread_reply_factory(thread_d, is_unapproved=True)
+
+    synchronize_category(default_category)
+
+    assert default_category.posts == 6
+    assert default_category.unapproved_posts == 4
+
+
+def test_synchronize_category_updates_sets_last_thread_by_user(
+    thread_factory, user, default_category
+):
+    thread_a = thread_factory(default_category)
+    thread_b = thread_factory(default_category, starter=user)
+    thread_c = thread_factory(default_category, is_hidden=True)
+    thread_d = thread_factory(default_category, is_unapproved=True)
+
+    synchronize_category(default_category)
+
+    assert default_category.last_posted_at == thread_b.last_posted_at
+    assert default_category.last_thread == thread_b
+    assert default_category.last_thread_title == thread_b.title
+    assert default_category.last_thread_slug == thread_b.slug
+    assert default_category.last_poster_id == thread_b.last_poster_id
+    assert default_category.last_poster_name == thread_b.last_poster_name
+    assert default_category.last_poster_slug == thread_b.last_poster_slug
+
+
+def test_synchronize_category_updates_sets_last_thread_by_deleted_user(
+    thread_factory, default_category
+):
+    thread_a = thread_factory(default_category)
+    thread_b = thread_factory(default_category)
+    thread_c = thread_factory(default_category, is_hidden=True)
+    thread_d = thread_factory(default_category, is_unapproved=True)
+
+    synchronize_category(default_category)
+
+    assert default_category.last_posted_at == thread_b.last_posted_at
+    assert default_category.last_thread == thread_b
+    assert default_category.last_thread_title == thread_b.title
+    assert default_category.last_thread_slug == thread_b.slug
+    assert default_category.last_poster_id is None
+    assert default_category.last_poster_name == thread_b.last_poster_name
+    assert default_category.last_poster_slug == thread_b.last_poster_slug
+
+
+def test_synchronize_category_clears_last_thread_in_empty_category(
+    user, default_category, user_private_thread
+):
+    default_category.last_posted_at == user_private_thread.last_posted_at
+    default_category.last_thread = user_private_thread
+    default_category.last_thread_title = user_private_thread.title
+    default_category.last_thread_slug = user_private_thread.slug
+    default_category.last_poster = user_private_thread.last_poster
+    default_category.last_poster_name = user_private_thread.last_poster_name
+    default_category.last_poster_slug = user_private_thread.last_poster_slug
+    default_category.save()
+
+    synchronize_category(default_category)
+
+    assert default_category.last_posted_at is None
+    assert default_category.last_thread is None
+    assert default_category.last_thread_title is None
+    assert default_category.last_thread_slug is None
+    assert default_category.last_poster_id is None
+    assert default_category.last_poster_name is None
+    assert default_category.last_poster_slug is None
+
+
+def test_synchronize_category_clears_last_thread_in_category_without_visible_threads(
+    thread_factory, user, default_category
+):
+    thread_c = thread_factory(default_category, is_hidden=True)
+    thread_d = thread_factory(default_category, is_unapproved=True)
+
+    default_category.last_posted_at = thread_d.last_posted_at
+    default_category.last_thread = thread_d
+    default_category.last_thread_title = thread_d.title
+    default_category.last_thread_slug = thread_d.slug
+    default_category.last_poster = thread_d.last_poster
+    default_category.last_poster_name = thread_d.last_poster_name
+    default_category.last_poster_slug = thread_d.last_poster_slug
+    default_category.save()
+
+    synchronize_category(default_category)
+
+    assert default_category.last_posted_at is None
+    assert default_category.last_thread is None
+    assert default_category.last_thread_title is None
+    assert default_category.last_thread_slug is None
+    assert default_category.last_poster_id is None
+    assert default_category.last_poster_name is None
+    assert default_category.last_poster_slug is None

--- a/misago/conftest.py
+++ b/misago/conftest.py
@@ -12,6 +12,7 @@ from .attachments.models import Attachment
 from .attachments.filetypes import filetypes
 from .cache.enums import CacheName
 from .categories.models import Category
+from .categories.synchronize import synchronize_category
 from .conf import SETTINGS_CACHE
 from .conf.dynamicsettings import DynamicSettings
 from .conf.staticsettings import StaticSettings
@@ -320,8 +321,7 @@ def default_category(db):
 def thread(thread_factory, default_category):
     thread = thread_factory(default_category)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -330,8 +330,7 @@ def thread(thread_factory, default_category):
 def other_thread(thread_factory, default_category):
     thread = thread_factory(default_category)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -340,8 +339,7 @@ def other_thread(thread_factory, default_category):
 def hidden_thread(thread_factory, default_category):
     thread = thread_factory(default_category, is_hidden=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -350,8 +348,7 @@ def hidden_thread(thread_factory, default_category):
 def unapproved_thread(thread_factory, default_category):
     thread = thread_factory(default_category, is_unapproved=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -369,8 +366,7 @@ def reply(thread_reply_factory, thread):
         original="I am reply",
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -384,8 +380,7 @@ def hidden_reply(thread_reply_factory, thread):
         is_hidden=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -399,8 +394,7 @@ def unapproved_reply(thread_reply_factory, thread):
         is_unapproved=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -413,8 +407,7 @@ def user_reply(thread_reply_factory, thread, user):
         original="I am user reply",
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -428,8 +421,7 @@ def user_hidden_reply(thread_reply_factory, thread, user):
         is_hidden=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -443,8 +435,7 @@ def user_unapproved_reply(thread_reply_factory, thread, user):
         is_unapproved=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -457,8 +448,7 @@ def other_user_reply(thread_reply_factory, thread, other_user):
         original="I am other user reply",
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -472,8 +462,7 @@ def other_user_hidden_reply(thread_reply_factory, thread, other_user):
         is_hidden=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -487,8 +476,7 @@ def other_user_unapproved_reply(thread_reply_factory, thread, other_user):
         is_unapproved=True,
     )
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -497,8 +485,7 @@ def other_user_unapproved_reply(thread_reply_factory, thread, other_user):
 def user_thread(thread_factory, default_category, user):
     thread = thread_factory(default_category, starter=user)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -507,8 +494,7 @@ def user_thread(thread_factory, default_category, user):
 def user_hidden_thread(thread_factory, default_category, user):
     thread = thread_factory(default_category, starter=user, is_hidden=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -517,8 +503,7 @@ def user_hidden_thread(thread_factory, default_category, user):
 def user_unapproved_thread(thread_factory, default_category, user):
     thread = thread_factory(default_category, starter=user, is_unapproved=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -527,8 +512,7 @@ def user_unapproved_thread(thread_factory, default_category, user):
 def other_user_thread(thread_factory, default_category, other_user):
     thread = thread_factory(default_category, starter=other_user)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -537,8 +521,7 @@ def other_user_thread(thread_factory, default_category, other_user):
 def other_user_hidden_thread(thread_factory, default_category, other_user):
     thread = thread_factory(default_category, starter=other_user, is_hidden=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -547,8 +530,7 @@ def other_user_hidden_thread(thread_factory, default_category, other_user):
 def other_user_unapproved_thread(thread_factory, default_category, other_user):
     thread = thread_factory(default_category, starter=other_user, is_unapproved=True)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -557,8 +539,7 @@ def other_user_unapproved_thread(thread_factory, default_category, other_user):
 def old_thread(thread_factory, default_category):
     thread = thread_factory(default_category, started_at=-3600)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -567,8 +548,7 @@ def old_thread(thread_factory, default_category):
 def old_user_thread(thread_factory, default_category, user):
     thread = thread_factory(default_category, started_at=-3600, starter=user)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -577,8 +557,7 @@ def old_user_thread(thread_factory, default_category, user):
 def old_other_user_thread(thread_factory, default_category, other_user):
     thread = thread_factory(default_category, started_at=-3600, starter=other_user)
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     return thread
 
@@ -587,8 +566,7 @@ def old_other_user_thread(thread_factory, default_category, other_user):
 def old_thread_reply(thread_reply_factory, old_thread):
     reply = thread_reply_factory(old_thread)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -597,8 +575,7 @@ def old_thread_reply(thread_reply_factory, old_thread):
 def old_thread_user_reply(thread_reply_factory, old_thread, user):
     reply = thread_reply_factory(old_thread, poster=user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -607,8 +584,7 @@ def old_thread_user_reply(thread_reply_factory, old_thread, user):
 def old_thread_other_user_reply(thread_reply_factory, old_thread, other_user):
     reply = thread_reply_factory(old_thread, poster=other_user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -617,8 +593,7 @@ def old_thread_other_user_reply(thread_reply_factory, old_thread, other_user):
 def old_user_thread_reply(thread_reply_factory, old_user_thread):
     reply = thread_reply_factory(old_user_thread)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -627,8 +602,7 @@ def old_user_thread_reply(thread_reply_factory, old_user_thread):
 def old_user_thread_user_reply(thread_reply_factory, old_user_thread, user):
     reply = thread_reply_factory(old_user_thread, poster=user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -637,8 +611,7 @@ def old_user_thread_user_reply(thread_reply_factory, old_user_thread, user):
 def old_user_thread_other_user_reply(thread_reply_factory, old_user_thread, other_user):
     reply = thread_reply_factory(old_user_thread, poster=other_user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -647,8 +620,7 @@ def old_user_thread_other_user_reply(thread_reply_factory, old_user_thread, othe
 def old_other_user_thread_reply(thread_reply_factory, old_other_user_thread):
     reply = thread_reply_factory(old_other_user_thread)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -657,8 +629,7 @@ def old_other_user_thread_reply(thread_reply_factory, old_other_user_thread):
 def old_other_user_thread_user_reply(thread_reply_factory, old_other_user_thread, user):
     reply = thread_reply_factory(old_other_user_thread, poster=user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -669,8 +640,7 @@ def old_other_user_thread_other_user_reply(
 ):
     reply = thread_reply_factory(old_other_user_thread, poster=other_user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -679,8 +649,7 @@ def old_other_user_thread_other_user_reply(
 def private_thread(thread_factory, private_threads_category):
     thread = thread_factory(private_threads_category)
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     return thread
 
@@ -694,8 +663,7 @@ def private_thread_post(private_thread):
 def private_thread_reply(thread_reply_factory, private_thread):
     reply = thread_reply_factory(private_thread, poster="Ghost")
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -704,8 +672,7 @@ def private_thread_reply(thread_reply_factory, private_thread):
 def private_thread_user_reply(thread_reply_factory, private_thread, user):
     reply = thread_reply_factory(private_thread, poster=user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 
@@ -724,8 +691,7 @@ def user_private_thread(
     PrivateThreadMember.objects.create(thread=thread, user=other_user, is_owner=False)
     PrivateThreadMember.objects.create(thread=thread, user=moderator, is_owner=False)
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     return thread
 
@@ -744,8 +710,7 @@ def other_user_private_thread(
     PrivateThreadMember.objects.create(thread=thread, user=user, is_owner=False)
     PrivateThreadMember.objects.create(thread=thread, user=moderator, is_owner=False)
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     return thread
 
@@ -754,8 +719,7 @@ def other_user_private_thread(
 def old_private_thread(thread_factory, private_threads_category):
     thread = thread_factory(private_threads_category, started_at=-3600)
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     return thread
 
@@ -764,8 +728,7 @@ def old_private_thread(thread_factory, private_threads_category):
 def old_private_thread_user_reply(thread_reply_factory, old_private_thread, user):
     reply = thread_reply_factory(old_private_thread, poster=user)
 
-    reply.category.synchronize()
-    reply.category.save()
+    synchronize_category(reply.category)
 
     return reply
 

--- a/misago/privatethreads/tests/test_private_thread_detail_read_tracking.py
+++ b/misago/privatethreads/tests/test_private_thread_detail_read_tracking.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.urls import reverse
 
+from ...categories.synchronize import synchronize_category
 from ...conf.test import override_dynamic_settings
 from ...notifications.users import notify_user
 from ...readtracker.models import ReadCategory, ReadThread
@@ -104,8 +105,7 @@ def test_private_thread_detail_view_marks_unread_thread_posts_on_page_as_read_fo
         posted_at = (8000 - (i * 1000)) * -1
         posts.append(thread_reply_factory(user_private_thread, posted_at=posted_at))
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     response = user_client.get(
         reverse(
@@ -252,8 +252,7 @@ def test_private_thread_detail_view_doesnt_update_user_unread_threads_count_on_t
         posted_at = (8000 - (i * 1000)) * -1
         posts.append(thread_reply_factory(user_private_thread, posted_at=posted_at))
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     response = user_client.get(
         reverse(

--- a/misago/privatethreads/tests/test_private_thread_list_view.py
+++ b/misago/privatethreads/tests/test_private_thread_list_view.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.urls import reverse
 
+from ...categories.synchronize import synchronize_category
 from ...pagination.cursor import EmptyPageError
 from ...permissions.models import Moderator
 from ...readtracker.models import ReadCategory, ReadThread
@@ -373,8 +374,7 @@ def test_private_thread_list_view_without_unread_threads_marks_category_as_read(
             read_time=thread.last_posted_at,
         )
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     create_user_private_thread_memberships(user)
 
@@ -412,8 +412,7 @@ def test_private_thread_list_view_without_unread_threads_clears_user_unread_thre
             read_time=thread.last_posted_at,
         )
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     create_user_private_thread_memberships(user)
 
@@ -453,8 +452,7 @@ def test_private_thread_list_view_with_read_entry_without_unread_threads_marks_c
         read_time=read_thread.last_posted_at,
     )
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     create_user_private_thread_memberships(user)
 
@@ -493,8 +491,7 @@ def test_private_thread_list_view_with_unread_thread_doesnt_mark_category_as_rea
         started_at=-600,
     )
 
-    private_threads_category.synchronize()
-    private_threads_category.save()
+    synchronize_category(private_threads_category)
 
     create_user_private_thread_memberships(user)
 

--- a/misago/threads/moderation/threads.py
+++ b/misago/threads/moderation/threads.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.utils import timezone
 
+from ...categories.synchronize import synchronize_category
 from ...notifications.tasks import delete_duplicate_watched_threads
 
 __all__ = [
@@ -139,8 +140,7 @@ def unhide_thread(request, thread):
     thread.save(update_fields=["is_hidden"])
 
     if thread.pk == thread.category.last_thread_id:
-        thread.category.synchronize()
-        thread.category.save()
+        synchronize_category(thread.category)
 
     return True
 
@@ -168,8 +168,7 @@ def hide_thread(request, thread):
     thread.save(update_fields=["is_hidden"])
 
     if thread.pk == thread.category.last_thread_id:
-        thread.category.synchronize()
-        thread.category.save()
+        synchronize_category(thread.category)
 
     return True
 
@@ -178,7 +177,6 @@ def hide_thread(request, thread):
 def delete_thread(request, thread):
     thread.delete()
 
-    thread.category.synchronize()
-    thread.category.save()
+    synchronize_category(thread.category)
 
     return True

--- a/misago/threads/signals.py
+++ b/misago/threads/signals.py
@@ -8,6 +8,7 @@ from django.utils.translation import pgettext
 from ..attachments.delete import delete_users_attachments
 from ..attachments.models import Attachment
 from ..categories.models import Category
+from ..categories.synchronize import synchronize_category
 from ..edits.models import PostEdit
 from ..likes.models import Like
 from ..likes.synchronize import synchronize_post_likes
@@ -135,8 +136,7 @@ def delete_user_threads(sender, **kwargs):
 
     if recount_categories:
         for category in Category.objects.filter(id__in=recount_categories):
-            category.synchronize()
-            category.save()
+            synchronize_category(category)
 
 
 @receiver(archive_user_data)

--- a/misago/threads/tasks.py
+++ b/misago/threads/tasks.py
@@ -1,0 +1,10 @@
+from celery import shared_task
+
+from .models import Thread
+from .synchronize import synchronize_thread
+
+
+@shared_task(name="threads.synchronize", serializer="json")
+def synchronize_threads(thread_ids: list[int]):
+    for thread in Thread.objects.filter(id__in=thread_ids):
+        synchronize_thread(thread)

--- a/misago/threads/tests/test_category_thread_list_view.py
+++ b/misago/threads/tests/test_category_thread_list_view.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from ...categories.enums import CategoryChildrenComponent
 from ...categories.models import Category
+from ...categories.synchronize import synchronize_category
 from ...conf.test import override_dynamic_settings
 from ...pagination.cursor import EmptyPageError
 from ...permissions.enums import CategoryPermission
@@ -1502,8 +1503,7 @@ def test_category_thread_list_view_marks_unread_category_without_unread_threads_
             read_time=thread.last_posted_at,
         )
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(default_category.get_absolute_url())
     assert response.status_code == 200
@@ -1542,8 +1542,7 @@ def test_category_thread_list_view_marks_unread_category_with_read_entry_without
         read_time=read_thread.last_posted_at,
     )
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(default_category.get_absolute_url())
     assert response.status_code == 200
@@ -1578,8 +1577,7 @@ def test_category_thread_list_view_doesnt_mark_unread_category_with_unread_threa
         started_at=-600,
     )
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(default_category.get_absolute_url())
     assert response.status_code == 200

--- a/misago/threads/tests/test_synchronize_threads_task.py
+++ b/misago/threads/tests/test_synchronize_threads_task.py
@@ -1,0 +1,17 @@
+from ..tasks import synchronize_threads
+
+
+def test_synchronize_threads_task_synchronizes_threads(thread, user_thread):
+    thread.replies = 100
+    thread.save()
+
+    user_thread.replies = 200
+    user_thread.save()
+
+    synchronize_threads([thread.id, user_thread.id])
+
+    thread.refresh_from_db()
+    assert thread.replies == 0
+
+    user_thread.refresh_from_db()
+    assert user_thread.replies == 0

--- a/misago/threads/tests/test_thread_detail_view_read_tracking.py
+++ b/misago/threads/tests/test_thread_detail_view_read_tracking.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.urls import reverse
 
+from ...categories.synchronize import synchronize_category
 from ...conf.test import override_dynamic_settings
 from ...notifications.users import notify_user
 from ...readtracker.models import ReadCategory, ReadThread
@@ -77,8 +78,7 @@ def test_thread_detail_view_marks_unread_thread_posts_on_page_as_read_for_user(
         posted_at = i * 100 * -1
         posts.append(thread_reply_factory(thread, posted_at=posted_at))
 
-    default_category.synchronize()
-    default_category.save()
+    synchronize_category(default_category)
 
     response = user_client.get(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),

--- a/misago/users/api/users.py
+++ b/misago/users/api/users.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 
 from ...acl.objectacl import add_acl_to_obj
 from ...categories.models import Category
+from ...categories.synchronize import synchronize_category
 from ...core.rest_permissions import IsAuthenticatedOrReadOnly
 from ...core.shortcuts import get_int_or_404
 from ...threads.moderation import hide_post, hide_thread
@@ -228,8 +229,7 @@ class UserViewSet(viewsets.GenericViewSet):
 
                     categories = Category.objects.filter(id__in=categories_to_sync)
                     for category in categories.iterator():
-                        category.synchronize()
-                        category.save()
+                        synchronize_category(category)
 
                 profile.delete(anonymous_username=request.settings.anonymous_username)
                 record_user_deleted_by_staff()

--- a/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
+++ b/plugins/misago-dev-site-fixture/misago_dev_site_fixture/management/commands/loaddevfixture.py
@@ -8,12 +8,14 @@ from django.utils import timezone
 from misago.cache.enums import CacheName
 from misago.cache.versions import get_cache_versions, invalidate_cache
 from misago.categories.models import Category
+from misago.categories.synchronize import synchronize_category
 from misago.conf.dynamicsettings import DynamicSettings
 from misago.conf.models import Setting
 from misago.permissions.enums import CategoryPermission
 from misago.permissions.models import CategoryGroupPermission
 from misago.threads.checksums import update_post_checksum
 from misago.threads.models import Post, Thread
+from misago.threads.synchronize import synchronize_thread
 from misago.users.enums import DefaultGroupId
 from misago.users.models import Ban, Group, Rank
 from misago.users.setupnewuser import setup_new_user
@@ -518,9 +520,6 @@ class Command(BaseCommand):
         moderator_post.update_search_vector()
         moderator_post.save()
 
-        thread_with_states.synchronize()
-        thread_with_states.save()
-
         thread_length = settings.posts_per_page + settings.posts_per_page_orphans
         timestamp = timezone.now() - timedelta(minutes=50)
 
@@ -558,9 +557,6 @@ class Command(BaseCommand):
             post.update_search_vector()
             post.save()
 
-        thread_one_page.synchronize()
-        thread_one_page.save()
-
         thread_length = settings.posts_per_page + settings.posts_per_page_orphans + 1
 
         thread_two_pages = Thread.objects.create(
@@ -596,9 +592,6 @@ class Command(BaseCommand):
             update_post_checksum(post)
             post.update_search_vector()
             post.save()
-
-        thread_two_pages.synchronize()
-        thread_two_pages.save()
 
         thread_length = (
             (settings.posts_per_page * 2) + settings.posts_per_page_orphans + 1
@@ -638,9 +631,6 @@ class Command(BaseCommand):
             post.update_search_vector()
             post.save()
 
-        thread_three_pages.synchronize()
-        thread_three_pages.save()
-
         timestamp = timezone.now()
         posts_to_update = Post.objects.filter(id__gt=yesterday_post.id).order_by("-id")
         for post in posts_to_update.iterator():
@@ -654,10 +644,6 @@ class Command(BaseCommand):
             post.save()
 
             timestamp -= timedelta(minutes=randint(1, 10))
-
-        for thread in Thread.objects.iterator():
-            thread.synchronize()
-            thread.save()
 
         timestamp = timezone.now()
 
@@ -810,8 +796,11 @@ class Command(BaseCommand):
         readme_post.update_search_vector()
         readme_post.save()
 
-        first_category.synchronize()
-        first_category.save()
+        for thread in Thread.objects.iterator():
+            synchronize_thread(thread)
+
+        for category in Category.objects.iterator():
+            synchronize_category(category)
 
         self.stdout.write("Created demo threads.")
 


### PR DESCRIPTION
Adds `synchronize_category` util together with a plugin hook. Removes `Category.synchronize` method.

Includes missing files from #2059 

Fixes #2055

