### PR TITLE
Add moderation options to the start thread pages

### DIFF
--- a/dev-docs/plugins/hooks/hide-thread-hook.md
+++ b/dev-docs/plugins/hooks/hide-thread-hook.md
@@ -96,7 +96,7 @@ The request object, or `None` if not provided.
 
 ## Example
 
-Register information about user who hid the thread
+Register user who hid the thread.
 
 ```python
 from django.http import HttpRequest

--- a/dev-docs/plugins/hooks/hide-thread-hook.md
+++ b/dev-docs/plugins/hooks/hide-thread-hook.md
@@ -1,0 +1,123 @@
+# `hide_thread_hook`
+
+This hook allows plugins to replace or extend the logic used to hide a thread.
+
+
+## Location
+
+This hook can be imported from `misago.threads.hooks`:
+
+```python
+from misago.threads.hooks import hide_thread_hook
+```
+
+
+## Filter
+
+```python
+def custom_hide_thread_filter(
+    action: HideThreadHookAction,
+    thread: Thread,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> bool:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: HideThreadHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `thread: Thread`
+
+A `Thread` to hide.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was hidden, `False` otherwise.
+
+
+## Action
+
+```python
+def hide_thread_action(
+    thread: Thread, commit: bool=True, request: HttpRequest | None=None
+) -> bool:
+    ...
+```
+
+Misago function for hiding a thread.
+
+
+### Arguments
+
+#### `thread: Thread`
+
+A `Thread` to hide.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was hidden, `False` otherwise.
+
+
+## Example
+
+Register information about user who hid the thread
+
+```python
+from django.http import HttpRequest
+from misago.threads.hooks import hide_thread_hook
+from misago.threads.models import Thread
+
+
+@hide_thread_hook.append_filter
+def register_user_that_hid_thread(
+    action,
+    thread: Thread,
+    commit: bool = True,
+    request: HttpRequest | None = None,
+) -> bool:
+    if not action(thread, commit=False, request=request):
+        return False
+
+    if request:
+        thread.plugin_data["hidden_by"] = request.user.id
+
+    if commit:
+        thread.save()
+
+    return True

--- a/dev-docs/plugins/hooks/lock-thread-hook.md
+++ b/dev-docs/plugins/hooks/lock-thread-hook.md
@@ -1,0 +1,123 @@
+# `lock_thread_hook`
+
+This hook allows plugins to replace or extend the logic used to lock a thread.
+
+
+## Location
+
+This hook can be imported from `misago.threads.hooks`:
+
+```python
+from misago.threads.hooks import lock_thread_hook
+```
+
+
+## Filter
+
+```python
+def custom_lock_thread_filter(
+    action: LockThreadHookAction,
+    thread: Thread,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> bool:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: LockThreadHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `thread: Thread`
+
+A `Thread` to lock.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was locked, `False` otherwise.
+
+
+## Action
+
+```python
+def lock_thread_action(
+    thread: Thread, commit: bool=True, request: HttpRequest | None=None
+) -> bool:
+    ...
+```
+
+Misago function for locking a thread.
+
+
+### Arguments
+
+#### `thread: Thread`
+
+A `Thread` to lock.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was locked, `False` otherwise.
+
+
+## Example
+
+Register information about user who locked the thread
+
+```python
+from django.http import HttpRequest
+from misago.threads.hooks import lock_thread_hook
+from misago.threads.models import Thread
+
+
+@lock_thread_hook.append_filter
+def register_user_that_locked_thread(
+    action,
+    thread: Thread,
+    commit: bool = True,
+    request: HttpRequest | None = None,
+) -> bool:
+    if not action(thread, commit=False, request=request):
+        return False
+
+    if request:
+        thread.plugin_data["locked_by"] = request.user.id
+
+    if commit:
+        thread.save()
+
+    return True

--- a/dev-docs/plugins/hooks/pin-thread-globally-hook.md
+++ b/dev-docs/plugins/hooks/pin-thread-globally-hook.md
@@ -1,6 +1,6 @@
-# `lock_thread_hook`
+# `pin_thread_globally_hook`
 
-This hook allows plugins to replace or extend the logic used to lock a thread.
+This hook allows plugins to replace or extend the logic used to pin a thread globally.
 
 
 ## Location
@@ -8,15 +8,15 @@ This hook allows plugins to replace or extend the logic used to lock a thread.
 This hook can be imported from `misago.threads.hooks`:
 
 ```python
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import pin_thread_globally_hook
 ```
 
 
 ## Filter
 
 ```python
-def custom_lock_thread_filter(
-    action: LockThreadHookAction,
+def custom_pin_thread_globally_filter(
+    action: PinThreadGloballyHookAction,
     thread: Thread,
     commit: bool=True,
     request: HttpRequest | None=None,
@@ -29,7 +29,7 @@ A function implemented by a plugin that can be registered in this hook.
 
 ### Arguments
 
-#### `action: LockThreadHookAction`
+#### `action: PinThreadGloballyHookAction`
 
 Next function registered in this hook, either a custom function or Misago's standard one.
 
@@ -38,7 +38,7 @@ See the [action](#action) section for details.
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to pin globally.
 
 
 #### `commit: bool = True`
@@ -55,26 +55,26 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was pinned, `False` otherwise.
 
 
 ## Action
 
 ```python
-def lock_thread_action(
+def pin_thread_globally_action(
     thread: Thread, commit: bool=True, request: HttpRequest | None=None
 ) -> bool:
     ...
 ```
 
-Misago function for locking a thread.
+Misago function for pinning a thread globally.
 
 
 ### Arguments
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to pin globally.
 
 
 #### `commit: bool = True`
@@ -91,21 +91,21 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was pinned, `False` otherwise.
 
 
 ## Example
 
-Register user who locked the thread.
+Register user who pinned the thread.
 
 ```python
 from django.http import HttpRequest
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import pin_thread_globally_hook
 from misago.threads.models import Thread
 
 
-@lock_thread_hook.append_filter
-def register_user_that_locked_thread(
+@pin_thread_globally_hook.append_filter
+def register_user_that_pinned_thread_globally(
     action,
     thread: Thread,
     commit: bool = True,
@@ -115,7 +115,7 @@ def register_user_that_locked_thread(
         return False
 
     if request:
-        thread.plugin_data["locked_by"] = request.user.id
+        thread.plugin_data["pinned_globally_by"] = request.user.id
 
     if commit:
         thread.save()

--- a/dev-docs/plugins/hooks/pin-thread-in-category-hook.md
+++ b/dev-docs/plugins/hooks/pin-thread-in-category-hook.md
@@ -1,6 +1,6 @@
-# `lock_thread_hook`
+# `pin_thread_in_category_hook`
 
-This hook allows plugins to replace or extend the logic used to lock a thread.
+This hook allows plugins to replace or extend the logic used to pin a thread in a category.
 
 
 ## Location
@@ -8,15 +8,15 @@ This hook allows plugins to replace or extend the logic used to lock a thread.
 This hook can be imported from `misago.threads.hooks`:
 
 ```python
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import pin_thread_in_category_hook
 ```
 
 
 ## Filter
 
 ```python
-def custom_lock_thread_filter(
-    action: LockThreadHookAction,
+def custom_pin_thread_in_category_filter(
+    action: PinThreadInCategoryHookAction,
     thread: Thread,
     commit: bool=True,
     request: HttpRequest | None=None,
@@ -29,7 +29,7 @@ A function implemented by a plugin that can be registered in this hook.
 
 ### Arguments
 
-#### `action: LockThreadHookAction`
+#### `action: PinThreadInCategoryHookAction`
 
 Next function registered in this hook, either a custom function or Misago's standard one.
 
@@ -38,7 +38,7 @@ See the [action](#action) section for details.
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to pin in a category.
 
 
 #### `commit: bool = True`
@@ -55,26 +55,26 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was pinned, `False` otherwise.
 
 
 ## Action
 
 ```python
-def lock_thread_action(
+def pin_thread_in_category_action(
     thread: Thread, commit: bool=True, request: HttpRequest | None=None
 ) -> bool:
     ...
 ```
 
-Misago function for locking a thread.
+Misago function for pinning a thread in a category.
 
 
 ### Arguments
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to pin in a category.
 
 
 #### `commit: bool = True`
@@ -91,21 +91,21 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was pinned, `False` otherwise.
 
 
 ## Example
 
-Register user who locked the thread.
+Register user who pinned the thread.
 
 ```python
 from django.http import HttpRequest
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import pin_thread_in_category_hook
 from misago.threads.models import Thread
 
 
-@lock_thread_hook.append_filter
-def register_user_that_locked_thread(
+@pin_thread_in_category_hook.append_filter
+def register_user_that_pinned_thread_in_category(
     action,
     thread: Thread,
     commit: bool = True,
@@ -115,7 +115,7 @@ def register_user_that_locked_thread(
         return False
 
     if request:
-        thread.plugin_data["locked_by"] = request.user.id
+        thread.plugin_data["pinned_in_category_by"] = request.user.id
 
     if commit:
         thread.save()

--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -292,9 +292,11 @@ Hooks instances are importable from the following Python modules:
 - [`get_threads_page_queryset_hook`](./get-threads-page-queryset-hook.md)
 - [`get_threads_page_subcategories_hook`](./get-threads-page-subcategories-hook.md)
 - [`get_threads_page_threads_hook`](./get-threads-page-threads-hook.md)
+- [`lock_thread_hook`](./lock-thread-hook.md)
 - [`move_threads_hook`](./move-threads-hook.md)
 - [`populate_post_feed_data_hook`](./populate-post-feed-data-hook.md)
 - [`synchronize_thread_hook`](./synchronize-thread-hook.md)
+- [`unlock_thread_hook`](./unlock-thread-hook.md)
 
 
 ## `misago.threadupdates.hooks`

--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -292,10 +292,12 @@ Hooks instances are importable from the following Python modules:
 - [`get_threads_page_queryset_hook`](./get-threads-page-queryset-hook.md)
 - [`get_threads_page_subcategories_hook`](./get-threads-page-subcategories-hook.md)
 - [`get_threads_page_threads_hook`](./get-threads-page-threads-hook.md)
+- [`hide_thread_hook`](./hide-thread-hook.md)
 - [`lock_thread_hook`](./lock-thread-hook.md)
 - [`move_threads_hook`](./move-threads-hook.md)
 - [`populate_post_feed_data_hook`](./populate-post-feed-data-hook.md)
 - [`synchronize_thread_hook`](./synchronize-thread-hook.md)
+- [`unhide_thread_hook`](./unhide-thread-hook.md)
 - [`unlock_thread_hook`](./unlock-thread-hook.md)
 
 

--- a/dev-docs/plugins/hooks/reference.md
+++ b/dev-docs/plugins/hooks/reference.md
@@ -295,10 +295,13 @@ Hooks instances are importable from the following Python modules:
 - [`hide_thread_hook`](./hide-thread-hook.md)
 - [`lock_thread_hook`](./lock-thread-hook.md)
 - [`move_threads_hook`](./move-threads-hook.md)
+- [`pin_thread_globally_hook`](./pin-thread-globally-hook.md)
+- [`pin_thread_in_category_hook`](./pin-thread-in-category-hook.md)
 - [`populate_post_feed_data_hook`](./populate-post-feed-data-hook.md)
 - [`synchronize_thread_hook`](./synchronize-thread-hook.md)
 - [`unhide_thread_hook`](./unhide-thread-hook.md)
 - [`unlock_thread_hook`](./unlock-thread-hook.md)
+- [`unpin_thread_hook`](./unpin-thread-hook.md)
 
 
 ## `misago.threadupdates.hooks`

--- a/dev-docs/plugins/hooks/unhide-thread-hook.md
+++ b/dev-docs/plugins/hooks/unhide-thread-hook.md
@@ -1,0 +1,123 @@
+# `unhide_thread_hook`
+
+This hook allows plugins to replace or extend the logic used to unhide a thread.
+
+
+## Location
+
+This hook can be imported from `misago.threads.hooks`:
+
+```python
+from misago.threads.hooks import unhide_thread_hook
+```
+
+
+## Filter
+
+```python
+def custom_unhide_thread_filter(
+    action: UnhideThreadHookAction,
+    thread: Thread,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> bool:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: UnhideThreadHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `thread: Thread`
+
+A `Thread` to unhide.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was unhidden, `False` otherwise.
+
+
+## Action
+
+```python
+def unhide_thread_action(
+    thread: Thread, commit: bool=True, request: HttpRequest | None=None
+) -> bool:
+    ...
+```
+
+Misago function for unhiding a thread.
+
+
+### Arguments
+
+#### `thread: Thread`
+
+A `Thread` to unhide.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was unhidden, `False` otherwise.
+
+
+## Example
+
+Register information about user who unhidden the thread
+
+```python
+from django.http import HttpRequest
+from misago.threads.hooks import unhide_thread_hook
+from misago.threads.models import Thread
+
+
+@unhide_thread_hook.append_filter
+def register_user_that_unhidden_thread(
+    action,
+    thread: Thread,
+    commit: bool = True,
+    request: HttpRequest | None = None,
+) -> bool:
+    if not action(thread, commit=False, request=request):
+        return False
+
+    if request:
+        thread.plugin_data["unhidden_by"] = request.user.id
+
+    if commit:
+        thread.save()
+
+    return True

--- a/dev-docs/plugins/hooks/unhide-thread-hook.md
+++ b/dev-docs/plugins/hooks/unhide-thread-hook.md
@@ -96,7 +96,7 @@ The request object, or `None` if not provided.
 
 ## Example
 
-Register information about user who unhidden the thread
+Register user who unhidden the thread.
 
 ```python
 from django.http import HttpRequest

--- a/dev-docs/plugins/hooks/unlock-thread-hook.md
+++ b/dev-docs/plugins/hooks/unlock-thread-hook.md
@@ -96,7 +96,7 @@ The request object, or `None` if not provided.
 
 ## Example
 
-Register information about user who unlocked the thread
+Register user who unlocked the thread.
 
 ```python
 from django.http import HttpRequest

--- a/dev-docs/plugins/hooks/unlock-thread-hook.md
+++ b/dev-docs/plugins/hooks/unlock-thread-hook.md
@@ -1,0 +1,123 @@
+# `unlock_thread_hook`
+
+This hook allows plugins to replace or extend the logic used to unlock a thread.
+
+
+## Location
+
+This hook can be imported from `misago.threads.hooks`:
+
+```python
+from misago.threads.hooks import unlock_thread_hook
+```
+
+
+## Filter
+
+```python
+def custom_unlock_thread_filter(
+    action: UnlockThreadHookAction,
+    thread: Thread,
+    commit: bool=True,
+    request: HttpRequest | None=None,
+) -> bool:
+    ...
+```
+
+A function implemented by a plugin that can be registered in this hook.
+
+
+### Arguments
+
+#### `action: UnlockThreadHookAction`
+
+Next function registered in this hook, either a custom function or Misago's standard one.
+
+See the [action](#action) section for details.
+
+
+#### `thread: Thread`
+
+A `Thread` to unlock.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was unlocked, `False` otherwise.
+
+
+## Action
+
+```python
+def unlock_thread_action(
+    thread: Thread, commit: bool=True, request: HttpRequest | None=None
+) -> bool:
+    ...
+```
+
+Misago function for unlocking a thread.
+
+
+### Arguments
+
+#### `thread: Thread`
+
+A `Thread` to unlock.
+
+
+#### `commit: bool = True`
+
+Whether the updated thread instance should be saved to the database.
+
+Defaults to `True`.
+
+
+#### `request: HttpRequest | None`
+
+The request object, or `None` if not provided.
+
+
+### Return value
+
+`True` if the thread was unlocked, `False` otherwise.
+
+
+## Example
+
+Register information about user who unlocked the thread
+
+```python
+from django.http import HttpRequest
+from misago.threads.hooks import unlock_thread_hook
+from misago.threads.models import Thread
+
+
+@unlock_thread_hook.append_filter
+def register_user_that_unlocked_thread(
+    action,
+    thread: Thread,
+    commit: bool = True,
+    request: HttpRequest | None = None,
+) -> bool:
+    if not action(thread, commit=False, request=request):
+        return False
+
+    if request:
+        thread.plugin_data["unlocked_by"] = request.user.id
+
+    if commit:
+        thread.save()
+
+    return True

--- a/dev-docs/plugins/hooks/unpin-thread-hook.md
+++ b/dev-docs/plugins/hooks/unpin-thread-hook.md
@@ -1,6 +1,6 @@
-# `lock_thread_hook`
+# `unpin_thread_hook`
 
-This hook allows plugins to replace or extend the logic used to lock a thread.
+This hook allows plugins to replace or extend the logic used to unpin a thread.
 
 
 ## Location
@@ -8,15 +8,15 @@ This hook allows plugins to replace or extend the logic used to lock a thread.
 This hook can be imported from `misago.threads.hooks`:
 
 ```python
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import unpin_thread_hook
 ```
 
 
 ## Filter
 
 ```python
-def custom_lock_thread_filter(
-    action: LockThreadHookAction,
+def custom_unpin_thread_filter(
+    action: UnpinThreadHookAction,
     thread: Thread,
     commit: bool=True,
     request: HttpRequest | None=None,
@@ -29,7 +29,7 @@ A function implemented by a plugin that can be registered in this hook.
 
 ### Arguments
 
-#### `action: LockThreadHookAction`
+#### `action: UnpinThreadHookAction`
 
 Next function registered in this hook, either a custom function or Misago's standard one.
 
@@ -38,7 +38,7 @@ See the [action](#action) section for details.
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to unpin.
 
 
 #### `commit: bool = True`
@@ -55,26 +55,26 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was unpinned, `False` otherwise.
 
 
 ## Action
 
 ```python
-def lock_thread_action(
+def unpin_thread_action(
     thread: Thread, commit: bool=True, request: HttpRequest | None=None
 ) -> bool:
     ...
 ```
 
-Misago function for locking a thread.
+Misago function for unpinning a thread.
 
 
 ### Arguments
 
 #### `thread: Thread`
 
-A `Thread` to lock.
+A `Thread` to unpin.
 
 
 #### `commit: bool = True`
@@ -91,21 +91,21 @@ The request object, or `None` if not provided.
 
 ### Return value
 
-`True` if the thread was locked, `False` otherwise.
+`True` if the thread was unpinned, `False` otherwise.
 
 
 ## Example
 
-Register user who locked the thread.
+Register user who unpinned the thread.
 
 ```python
 from django.http import HttpRequest
-from misago.threads.hooks import lock_thread_hook
+from misago.threads.hooks import unpin_thread_hook
 from misago.threads.models import Thread
 
 
-@lock_thread_hook.append_filter
-def register_user_that_locked_thread(
+@unpin_thread_hook.append_filter
+def register_user_that_unpinned_thread(
     action,
     thread: Thread,
     commit: bool = True,
@@ -115,7 +115,7 @@ def register_user_that_locked_thread(
         return False
 
     if request:
-        thread.plugin_data["locked_by"] = request.user.id
+        thread.plugin_data["unpinned_by"] = request.user.id
 
     if commit:
         thread.save()

--- a/misago/posting/forms/__init__.py
+++ b/misago/posting/forms/__init__.py
@@ -2,7 +2,12 @@ from .attachments import MultipleFileField
 from .base import PostingForm
 from .editreason import EditReasonForm, create_edit_reason_form
 from .members import MembersForm, create_members_form
-from .moderation import ThreadModerationForm, create_thread_moderation_form
+from .moderation import (
+    PrivateThreadModerationForm,
+    ThreadModerationForm,
+    create_private_thread_moderation_form,
+    create_thread_moderation_form,
+)
 from .poll import PollForm, create_poll_form
 from .post import PostForm, create_post_form
 from .title import TitleForm, create_title_form
@@ -15,12 +20,14 @@ __all__ = [
     "PollForm",
     "PostForm",
     "PostingForm",
+    "PrivateThreadModerationForm",
     "ThreadModerationForm",
     "TitleForm",
     "create_edit_reason_form",
     "create_members_form",
     "create_poll_form",
     "create_post_form",
+    "create_private_thread_moderation_form",
     "create_thread_moderation_form",
     "create_title_form",
 ]

--- a/misago/posting/forms/__init__.py
+++ b/misago/posting/forms/__init__.py
@@ -2,6 +2,7 @@ from .attachments import MultipleFileField
 from .base import PostingForm
 from .editreason import EditReasonForm, create_edit_reason_form
 from .members import MembersForm, create_members_form
+from .moderation import ThreadModerationForm, create_thread_moderation_form
 from .poll import PollForm, create_poll_form
 from .post import PostForm, create_post_form
 from .title import TitleForm, create_title_form
@@ -14,10 +15,12 @@ __all__ = [
     "PollForm",
     "PostForm",
     "PostingForm",
+    "ThreadModerationForm",
     "TitleForm",
     "create_edit_reason_form",
     "create_members_form",
     "create_poll_form",
     "create_post_form",
+    "create_thread_moderation_form",
     "create_title_form",
 ]

--- a/misago/posting/forms/moderation.py
+++ b/misago/posting/forms/moderation.py
@@ -67,3 +67,36 @@ def create_thread_moderation_form(
         is_global_moderator=global_moderator,
         prefix=ThreadModerationForm.form_prefix,
     )
+
+
+class PrivateThreadModerationForm(PostingForm):
+    form_prefix = "posting-moderation"
+    template_name = "misago/posting/private_thread_moderation_form.html"
+
+    request: HttpRequest
+
+    is_locked = forms.BooleanField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super().__init__(*args, **kwargs)
+
+    def update_state(self, state: StartState):
+        if self.cleaned_data["is_locked"]:
+            lock_thread(state.thread, commit=False, request=self.request)
+
+
+def create_private_thread_moderation_form(
+    request: HttpRequest,
+) -> PrivateThreadModerationForm:
+    if request.method == "POST":
+        return PrivateThreadModerationForm(
+            request.POST,
+            request=request,
+            prefix=ThreadModerationForm.form_prefix,
+        )
+
+    return PrivateThreadModerationForm(
+        request=request,
+        prefix=ThreadModerationForm.form_prefix,
+    )

--- a/misago/posting/forms/moderation.py
+++ b/misago/posting/forms/moderation.py
@@ -1,0 +1,69 @@
+from django import forms
+from django.http import HttpRequest
+from django.utils.translation import pgettext_lazy
+
+from ...threads.enums import ThreadWeight
+from ...threads.hide import hide_thread
+from ...threads.lock import lock_thread
+from ...threads.pin import pin_thread_globally, pin_thread_in_category
+from ..state import StartState
+from .base import PostingForm
+
+
+class ThreadModerationForm(PostingForm):
+    form_prefix = "posting-moderation"
+    template_name = "misago/posting/thread_moderation_form.html"
+
+    request: HttpRequest
+
+    is_locked = forms.BooleanField(required=False)
+    is_hidden = forms.BooleanField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        is_global_moderator = kwargs.pop("is_global_moderator")
+
+        super().__init__(*args, **kwargs)
+
+        if is_global_moderator:
+            self.fields["pin"] = forms.TypedChoiceField(
+                choices=ThreadWeight.get_choices(),
+                coerce=int,
+                required=False,
+                initial=ThreadWeight.NOT_PINNED,
+            )
+        else:
+            self.fields["pin_in_category"] = forms.BooleanField(required=False)
+
+    def update_state(self, state: StartState):
+        if self.cleaned_data["is_locked"]:
+            lock_thread(state.thread, commit=False, request=self.request)
+
+        if self.cleaned_data["is_hidden"]:
+            hide_thread(state.thread, commit=False, request=self.request)
+
+        if (
+            self.cleaned_data.get("pin_in_category")
+            or self.cleaned_data.get("pin") == ThreadWeight.PINNED_IN_CATEGORY
+        ):
+            pin_thread_in_category(state.thread, commit=False, request=self.request)
+        elif self.cleaned_data.get("pin") == ThreadWeight.PINNED_GLOBALLY:
+            pin_thread_globally(state.thread, commit=False, request=self.request)
+
+
+def create_thread_moderation_form(
+    request: HttpRequest, global_moderator: bool
+) -> ThreadModerationForm:
+    if request.method == "POST":
+        return ThreadModerationForm(
+            request.POST,
+            request=request,
+            is_global_moderator=global_moderator,
+            prefix=ThreadModerationForm.form_prefix,
+        )
+
+    return ThreadModerationForm(
+        request=request,
+        is_global_moderator=global_moderator,
+        prefix=ThreadModerationForm.form_prefix,
+    )

--- a/misago/posting/formsets/start.py
+++ b/misago/posting/formsets/start.py
@@ -13,10 +13,14 @@ from ..forms import (
     create_members_form,
     create_poll_form,
     create_post_form,
+    create_private_thread_moderation_form,
     create_thread_moderation_form,
     create_title_form,
 )
-from ..hooks import get_private_thread_start_formset_hook, get_thread_start_formset_hook
+from ..hooks import (
+    get_private_thread_start_formset_hook,
+    get_thread_start_formset_hook,
+)
 from .formset import Formset, TabbedFormset
 
 
@@ -107,5 +111,8 @@ def _get_private_thread_start_formset_action(
             can_upload_attachments=can_upload_attachments,
         )
     )
+
+    if request.user_permissions.is_private_threads_moderator:
+        formset.add_form(create_private_thread_moderation_form(request))
 
     return formset

--- a/misago/posting/formsets/start.py
+++ b/misago/posting/formsets/start.py
@@ -13,6 +13,7 @@ from ..forms import (
     create_members_form,
     create_poll_form,
     create_post_form,
+    create_thread_moderation_form,
     create_title_form,
 )
 from ..hooks import get_private_thread_start_formset_hook, get_thread_start_formset_hook
@@ -67,6 +68,14 @@ def _get_thread_start_formset_action(
         formset.add_form(
             ThreadStartFormsetTabs.POLL,
             create_poll_form(request),
+        )
+
+    if request.user_permissions.is_category_moderator(category.id):
+        formset.add_form(
+            ThreadStartFormsetTabs.CONTENT,
+            create_thread_moderation_form(
+                request, request.user_permissions.is_global_moderator
+            ),
         )
 
     return formset

--- a/misago/posting/tests/test_private_thread_start_view.py
+++ b/misago/posting/tests/test_private_thread_start_view.py
@@ -8,6 +8,7 @@ from ...conf.test import override_dynamic_settings
 from ...notifications.enums import ThreadNotifications
 from ...notifications.models import WatchedThread
 from ...permissions.enums import CanUploadAttachments
+from ...permissions.models import Moderator
 from ...test import assert_contains, assert_contains_element, assert_not_contains
 from ...threads.models import Thread
 from ..forms import PostForm
@@ -53,6 +54,29 @@ def test_private_thread_start_view_shows_error_403_to_users_without_start_privat
 def test_private_thread_start_view_displays_posting_form(user_client):
     response = user_client.get(reverse("misago:private-thread-start"))
     assert_contains(response, "Start thread")
+    assert_not_contains(response, "Lock thread")
+
+
+def test_private_thread_start_view_displays_posting_form_with_moderation_options_for_private_threads_moderator(
+    user_client, user
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        private_threads=True,
+    )
+
+    response = user_client.get(reverse("misago:private-thread-start"))
+    assert_contains(response, "Start thread")
+    assert_contains(response, "Lock thread")
+
+
+def test_private_thread_start_view_displays_posting_form_with_moderation_options_for_global_moderator(
+    moderator_client,
+):
+    response = moderator_client.get(reverse("misago:private-thread-start"))
+    assert_contains(response, "Start thread")
+    assert_contains(response, "Lock thread")
 
 
 def test_private_thread_start_view_posts_new_thread(
@@ -145,13 +169,189 @@ def test_private_thread_start_view_posts_new_unapproved_thread(
     assert response.status_code == 302
 
     thread = Thread.objects.get(slug="hello-world")
-    assert thread.is_unapproved
     assert response["location"] == reverse(
         "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
     )
 
+    assert thread.is_unapproved
+
     mock_notify_on_new_private_thread.delay.assert_called_with(
         user.id, thread.id, [admin.id, moderator.id, other_user.id]
+    )
+
+
+def test_private_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_not_moderator(
+    user_client, user, admin, moderator, other_user, mock_notify_on_new_private_thread
+):
+    response = user_client.post(
+        reverse("misago:private-thread-start"),
+        {
+            "posting-members-users": [
+                admin.username,
+                moderator.username,
+                other_user.username,
+            ],
+            "posting-members-users_noscript": "",
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-is_locked": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.is_locked
+
+    mock_notify_on_new_private_thread.delay.assert_called_with(
+        user.id, thread.id, [admin.id, moderator.id, other_user.id]
+    )
+
+
+def test_private_thread_start_view_posts_new_thread_with_moderation_options_if_user_is_private_threads_moderator(
+    user_client, user, admin, moderator, other_user, mock_notify_on_new_private_thread
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        private_threads=True,
+    )
+
+    response = user_client.post(
+        reverse("misago:private-thread-start"),
+        {
+            "posting-members-users": [
+                admin.username,
+                moderator.username,
+                other_user.username,
+            ],
+            "posting-members-users_noscript": "",
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-is_locked": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert thread.is_locked
+
+    mock_notify_on_new_private_thread.delay.assert_called_with(
+        user.id, thread.id, [admin.id, moderator.id, other_user.id]
+    )
+
+
+def test_private_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_private_threads_moderator(
+    user_client, user, admin, moderator, other_user, mock_notify_on_new_private_thread
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        private_threads=True,
+    )
+
+    response = user_client.post(
+        reverse("misago:private-thread-start"),
+        {
+            "posting-members-users": [
+                admin.username,
+                moderator.username,
+                other_user.username,
+            ],
+            "posting-members-users_noscript": "",
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.is_locked
+
+    mock_notify_on_new_private_thread.delay.assert_called_with(
+        user.id, thread.id, [admin.id, moderator.id, other_user.id]
+    )
+
+
+def test_private_thread_start_view_posts_new_thread_with_moderation_options_if_user_is_global_moderator(
+    moderator_client,
+    user,
+    admin,
+    moderator,
+    other_user,
+    mock_notify_on_new_private_thread,
+):
+    response = moderator_client.post(
+        reverse("misago:private-thread-start"),
+        {
+            "posting-members-users": [
+                admin.username,
+                user.username,
+                other_user.username,
+            ],
+            "posting-members-users_noscript": "",
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-is_locked": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert thread.is_locked
+
+    mock_notify_on_new_private_thread.delay.assert_called_with(
+        moderator.id, thread.id, [admin.id, user.id, other_user.id]
+    )
+
+
+def test_private_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_global_moderator(
+    moderator_client,
+    user,
+    admin,
+    moderator,
+    other_user,
+    mock_notify_on_new_private_thread,
+):
+    response = moderator_client.post(
+        reverse("misago:private-thread-start"),
+        {
+            "posting-members-users": [
+                admin.username,
+                user.username,
+                other_user.username,
+            ],
+            "posting-members-users_noscript": "",
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:private-thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.is_locked
+
+    mock_notify_on_new_private_thread.delay.assert_called_with(
+        moderator.id, thread.id, [admin.id, user.id, other_user.id]
     )
 
 

--- a/misago/posting/tests/test_thread_start_view.py
+++ b/misago/posting/tests/test_thread_start_view.py
@@ -10,10 +10,11 @@ from ...conf.test import override_dynamic_settings
 from ...notifications.enums import ThreadNotifications
 from ...notifications.models import WatchedThread
 from ...permissions.enums import CanUploadAttachments, CategoryPermission
-from ...permissions.models import CategoryGroupPermission
+from ...permissions.models import CategoryGroupPermission, Moderator
 from ...polls.enums import PublicPollsAvailability
 from ...polls.models import Poll
 from ...test import assert_contains, assert_contains_element, assert_not_contains
+from ...threads.enums import ThreadWeight
 from ...threads.models import Thread
 from ..forms import PostForm
 from ..formsets import Formset
@@ -115,6 +116,59 @@ def test_thread_start_view_displays_posting_form(user_client, default_category):
     assert_contains(response, "Start thread")
     assert_contains(response, default_category.name)
 
+    assert_not_contains(response, "Pin thread globally")
+    assert_not_contains(response, "Pin thread in category")
+    assert_not_contains(response, "Hide thread")
+    assert_not_contains(response, "Lock thread")
+
+
+def test_thread_start_view_displays_posting_form_with_moderation_options_for_category_moderator(
+    user_client, user, default_category
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        categories=[default_category.id],
+    )
+
+    response = user_client.get(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        )
+    )
+    assert_contains(response, "Start thread")
+    assert_contains(response, default_category.name)
+
+    assert_not_contains(response, "Pin thread globally")
+    assert_contains(response, "Pin thread in category")
+    assert_contains(response, "Hide thread")
+    assert_contains(response, "Lock thread")
+
+
+def test_thread_start_view_displays_posting_form_with_moderation_options_for_global_moderator(
+    moderator_client, default_category
+):
+    response = moderator_client.get(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        )
+    )
+    assert_contains(response, "Start thread")
+    assert_contains(response, default_category.name)
+
+    assert_contains(response, "Pin thread globally")
+    assert_contains(response, "Pin thread in category")
+    assert_contains(response, "Hide thread")
+    assert_contains(response, "Lock thread")
+
 
 def test_thread_start_view_posts_new_thread(user_client, default_category):
     response = user_client.post(
@@ -160,10 +214,207 @@ def test_thread_start_view_posts_new_unapproved_thread(
     assert response.status_code == 302
 
     thread = Thread.objects.get(slug="hello-world")
-    assert thread.is_unapproved
     assert response["location"] == reverse(
         "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
     )
+
+    assert thread.is_unapproved
+
+
+def test_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_not_moderator(
+    user_client, default_category
+):
+    response = user_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-pin": "2",
+            "posting-moderation-is_locked": "true",
+            "posting-moderation-is_hidden": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.weight
+    assert not thread.is_locked
+    assert not thread.is_hidden
+
+
+def test_thread_start_view_posts_new_thread_with_moderation_options_if_user_is_category_moderator(
+    user_client, user, default_category
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        categories=[default_category.id],
+    )
+
+    response = user_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-pin_in_category": "true",
+            "posting-moderation-is_locked": "true",
+            "posting-moderation-is_hidden": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+    assert thread.is_locked
+    assert thread.is_hidden
+
+
+def test_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_category_moderator(
+    user_client, user, default_category
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        categories=[default_category.id],
+    )
+
+    response = user_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.weight
+    assert not thread.is_locked
+    assert not thread.is_hidden
+
+
+def test_thread_start_view_posts_new_thread_with_global_pin_if_user_is_category_moderator(
+    user_client, user, default_category
+):
+    Moderator.objects.create(
+        user=user,
+        is_global=False,
+        categories=[default_category.id],
+    )
+
+    response = user_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-pin": str(ThreadWeight.PINNED_GLOBALLY),
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.weight
+    assert not thread.is_locked
+    assert not thread.is_hidden
+
+
+def test_thread_start_view_posts_new_thread_with_moderation_options_if_user_is_global_moderator(
+    moderator_client, default_category
+):
+    response = moderator_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+            "posting-moderation-pin": str(ThreadWeight.PINNED_GLOBALLY.value),
+            "posting-moderation-is_locked": "true",
+            "posting-moderation-is_hidden": "true",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+    assert thread.is_locked
+    assert thread.is_hidden
+
+
+def test_thread_start_view_posts_new_thread_without_moderation_options_if_user_is_global_moderator(
+    moderator_client, default_category
+):
+    response = moderator_client.post(
+        reverse(
+            "misago:thread-start",
+            kwargs={
+                "category_id": default_category.id,
+                "slug": default_category.slug,
+            },
+        ),
+        {
+            "posting-title-title": "Hello world",
+            "posting-post-post": "How's going?",
+        },
+    )
+    assert response.status_code == 302
+
+    thread = Thread.objects.get(slug="hello-world")
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    assert not thread.weight
+    assert not thread.is_locked
+    assert not thread.is_hidden
 
 
 def test_thread_start_view_previews_new_thread(user_client, default_category):

--- a/misago/templates/misago/posting/private_thread_moderation_form.html
+++ b/misago/templates/misago/posting/private_thread_moderation_form.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% with field=form.is_locked %}
+  <div class="checkbox">
+    <label>
+      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+    </label>
+  </div>
+{% endwith %}

--- a/misago/templates/misago/posting/private_thread_moderation_form.html
+++ b/misago/templates/misago/posting/private_thread_moderation_form.html
@@ -3,7 +3,7 @@
 {% with field=form.is_locked %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}

--- a/misago/templates/misago/posting/private_thread_moderation_form.html
+++ b/misago/templates/misago/posting/private_thread_moderation_form.html
@@ -3,7 +3,7 @@
 {% with field=form.is_locked %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="{{ field.value}}"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}

--- a/misago/templates/misago/posting/thread_moderation_form.html
+++ b/misago/templates/misago/posting/thread_moderation_form.html
@@ -18,7 +18,7 @@
   {% with field=form.pin_in_category %}
     <div class="checkbox">
       <label>
-        <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Pin thread in category" context "posting moderation form" %}
+        <input name="{{ field.html_name }}" type="checkbox" value="{{ field.value}}"{% if field.data %} checked{% endif %}> {% translate "Pin thread in category" context "posting moderation form" %}
       </label>
     </div>
   {% endwith %}
@@ -26,14 +26,14 @@
 {% with field=form.is_locked %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="{{ field.value}}"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}
 {% with field=form.is_hidden %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Hide thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="{{ field.value}}"{% if field.data %} checked{% endif %}> {% translate "Hide thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}

--- a/misago/templates/misago/posting/thread_moderation_form.html
+++ b/misago/templates/misago/posting/thread_moderation_form.html
@@ -18,7 +18,7 @@
   {% with field=form.pin_in_category %}
     <div class="checkbox">
       <label>
-        <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Pin thread in category" context "posting moderation form" %}
+        <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Pin thread in category" context "posting moderation form" %}
       </label>
     </div>
   {% endwith %}
@@ -26,14 +26,14 @@
 {% with field=form.is_locked %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}
 {% with field=form.is_hidden %}
   <div class="checkbox">
     <label>
-      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Hide thread" context "posting moderation form" %}
+      <input name="{{ field.html_name }}" type="checkbox" value="1"{% if field.data %} checked{% endif %}> {% translate "Hide thread" context "posting moderation form" %}
     </label>
   </div>
 {% endwith %}

--- a/misago/templates/misago/posting/thread_moderation_form.html
+++ b/misago/templates/misago/posting/thread_moderation_form.html
@@ -1,0 +1,39 @@
+{% load i18n misago_forms %}
+
+{% if form.pin %}
+  {% with field=form.pin %}
+    <div class="form-control-choices">
+      {% for choice in field.subwidgets %}
+        <div class="radio">
+          <label>
+            <input type="radio" name="{{ field.html_name }}" value="{{ choice.data.value }}"{{ choice|checkedhtml }}>
+            {{ choice.choice_label }}
+          </label>
+        </div>
+      {% endfor %}
+    </div>
+  {% endwith %}
+{% endif %}
+{% if form.pin_in_category %}
+  {% with field=form.pin_in_category %}
+    <div class="checkbox">
+      <label>
+        <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Pin thread in category" context "posting moderation form" %}
+      </label>
+    </div>
+  {% endwith %}
+{% endif %}
+{% with field=form.is_locked %}
+  <div class="checkbox">
+    <label>
+      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Lock thread" context "posting moderation form" %}
+    </label>
+  </div>
+{% endwith %}
+{% with field=form.is_hidden %}
+  <div class="checkbox">
+    <label>
+      <input name="{{ field.html_name }}" type="checkbox"{% if field.data %} checked{% endif %}> {% translate "Hide thread" context "posting moderation form" %}
+    </label>
+  </div>
+{% endwith %}

--- a/misago/threads/enums.py
+++ b/misago/threads/enums.py
@@ -8,6 +8,23 @@ class ThreadWeight(IntEnum):
     PINNED_IN_CATEGORY = 1
     PINNED_GLOBALLY = 2
 
+    @classmethod
+    def get_choices(cls):
+        return (
+            (
+                cls.NOT_PINNED,
+                pgettext_lazy("pin thread choice", "Don't pin thread"),
+            ),
+            (
+                cls.PINNED_IN_CATEGORY,
+                pgettext_lazy("pin thread choice", "Pin thread in category"),
+            ),
+            (
+                cls.PINNED_GLOBALLY,
+                pgettext_lazy("pin thread choice", "Pin thread globally"),
+            ),
+        )
+
 
 class ThreadsListsPolling(IntEnum):
     DISABLED = 0

--- a/misago/threads/hide.py
+++ b/misago/threads/hide.py
@@ -1,16 +1,19 @@
+from django.http import HttpRequest
+
+from .hooks import hide_thread_hook, unhide_thread_hook
 from .models import Thread
 
 
 def hide_thread(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    return _hide_thread_action(thread, commit, request)
+    return hide_thread_hook(_hide_thread_action, thread, commit, request)
 
 
 def _hide_thread_action(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    if not thread.is_hidden:
+    if thread.is_hidden:
         return False
 
     thread.is_hidden = True
@@ -24,13 +27,13 @@ def _hide_thread_action(
 def unhide_thread(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    return _unhide_thread_action(thread, commit, request)
+    return unhide_thread_hook(_unhide_thread_action, thread, commit, request)
 
 
 def _unhide_thread_action(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    if thread.is_hidden:
+    if not thread.is_hidden:
         return False
 
     thread.is_hidden = False

--- a/misago/threads/hide.py
+++ b/misago/threads/hide.py
@@ -1,0 +1,41 @@
+from .models import Thread
+
+
+def hide_thread(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return _hide_thread_action(thread, commit, request)
+
+
+def _hide_thread_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if not thread.is_hidden:
+        return False
+
+    thread.is_hidden = True
+
+    if commit:
+        thread.save()
+
+    return True
+
+
+def unhide_thread(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return _unhide_thread_action(thread, commit, request)
+
+
+def _unhide_thread_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if thread.is_hidden:
+        return False
+
+    thread.is_hidden = False
+
+    if commit:
+        thread.save()
+
+    return True

--- a/misago/threads/hooks/__init__.py
+++ b/misago/threads/hooks/__init__.py
@@ -31,10 +31,12 @@ from .get_threads_page_moderation_actions import (
 from .get_threads_page_queryset import get_threads_page_queryset_hook
 from .get_threads_page_subcategories import get_threads_page_subcategories_hook
 from .get_threads_page_threads import get_threads_page_threads_hook
+from .hide_thread import hide_thread_hook
 from .lock_thread import lock_thread_hook
 from .move_threads import move_threads_hook
 from .populate_post_feed_data import populate_post_feed_data_hook
 from .synchronize_thread import synchronize_thread_hook
+from .unhide_thread import unhide_thread_hook
 from .unlock_thread import unlock_thread_hook
 
 __all__ = [
@@ -55,9 +57,11 @@ __all__ = [
     "get_threads_page_queryset_hook",
     "get_threads_page_subcategories_hook",
     "get_threads_page_threads_hook",
+    "hide_thread_hook",
     "lock_thread_hook",
     "move_threads_hook",
     "populate_post_feed_data_hook",
     "synchronize_thread_hook",
+    "unhide_thread_hook",
     "unlock_thread_hook",
 ]

--- a/misago/threads/hooks/__init__.py
+++ b/misago/threads/hooks/__init__.py
@@ -31,9 +31,11 @@ from .get_threads_page_moderation_actions import (
 from .get_threads_page_queryset import get_threads_page_queryset_hook
 from .get_threads_page_subcategories import get_threads_page_subcategories_hook
 from .get_threads_page_threads import get_threads_page_threads_hook
+from .lock_thread import lock_thread_hook
 from .move_threads import move_threads_hook
 from .populate_post_feed_data import populate_post_feed_data_hook
 from .synchronize_thread import synchronize_thread_hook
+from .unlock_thread import unlock_thread_hook
 
 __all__ = [
     "create_prefetch_post_feed_data_hook",
@@ -53,7 +55,9 @@ __all__ = [
     "get_threads_page_queryset_hook",
     "get_threads_page_subcategories_hook",
     "get_threads_page_threads_hook",
+    "lock_thread_hook",
     "move_threads_hook",
     "populate_post_feed_data_hook",
     "synchronize_thread_hook",
+    "unlock_thread_hook",
 ]

--- a/misago/threads/hooks/__init__.py
+++ b/misago/threads/hooks/__init__.py
@@ -34,10 +34,13 @@ from .get_threads_page_threads import get_threads_page_threads_hook
 from .hide_thread import hide_thread_hook
 from .lock_thread import lock_thread_hook
 from .move_threads import move_threads_hook
+from .pin_thread_globally import pin_thread_globally_hook
+from .pin_thread_in_category import pin_thread_in_category_hook
 from .populate_post_feed_data import populate_post_feed_data_hook
 from .synchronize_thread import synchronize_thread_hook
 from .unhide_thread import unhide_thread_hook
 from .unlock_thread import unlock_thread_hook
+from .unpin_thread import unpin_thread_hook
 
 __all__ = [
     "create_prefetch_post_feed_data_hook",
@@ -60,8 +63,11 @@ __all__ = [
     "hide_thread_hook",
     "lock_thread_hook",
     "move_threads_hook",
+    "pin_thread_globally_hook",
+    "pin_thread_in_category_hook",
     "populate_post_feed_data_hook",
     "synchronize_thread_hook",
     "unhide_thread_hook",
     "unlock_thread_hook",
+    "unpin_thread_hook",
 ]

--- a/misago/threads/hooks/hide_thread.py
+++ b/misago/threads/hooks/hide_thread.py
@@ -1,0 +1,139 @@
+from typing import Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ..models import Thread
+
+
+class HideThreadHookAction(Protocol):
+    """
+    Misago function for hiding a thread.
+
+    # Arguments
+
+    ## `thread: Thread`
+
+    A `Thread` to hide.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was hidden, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class HideThreadHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: HideThreadHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `thread: Thread`
+
+    A `Thread` to hide.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was hidden, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        action: HideThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class HideThreadHook(
+    FilterHook[
+        HideThreadHookAction,
+        HideThreadHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the logic used to
+    hide a thread.
+
+    # Example
+
+    Register information about user who hid the thread
+
+    ```python
+    from django.http import HttpRequest
+    from misago.threads.hooks import hide_thread_hook
+    from misago.threads.models import Thread
+
+
+    @hide_thread_hook.append_filter
+    def register_user_that_hid_thread(
+        action,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        if not action(thread, commit=False, request=request):
+            return False
+
+        if request:
+            thread.plugin_data["hidden_by"] = request.user.id
+
+        if commit:
+            thread.save()
+
+        return True
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: HideThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        return super().__call__(
+            action,
+            thread,
+            commit,
+            request,
+        )
+
+
+hide_thread_hook = HideThreadHook()

--- a/misago/threads/hooks/lock_thread.py
+++ b/misago/threads/hooks/lock_thread.py
@@ -92,7 +92,7 @@ class LockThreadHook(
 
     # Example
 
-    Register information about user who locked the thread
+    Register user who locked the thread.
 
     ```python
     from django.http import HttpRequest

--- a/misago/threads/hooks/lock_thread.py
+++ b/misago/threads/hooks/lock_thread.py
@@ -1,0 +1,139 @@
+from typing import Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ..models import Thread
+
+
+class LockThreadHookAction(Protocol):
+    """
+    Misago function for locking a thread.
+
+    # Arguments
+
+    ## `thread: Thread`
+
+    A `Thread` to lock.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was locked, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class LockThreadHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: LockThreadHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `thread: Thread`
+
+    A `Thread` to lock.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was locked, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        action: LockThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class LockThreadHook(
+    FilterHook[
+        LockThreadHookAction,
+        LockThreadHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the logic used to
+    lock a thread.
+
+    # Example
+
+    Register information about user who locked the thread
+
+    ```python
+    from django.http import HttpRequest
+    from misago.threads.hooks import lock_thread_hook
+    from misago.threads.models import Thread
+
+
+    @lock_thread_hook.append_filter
+    def register_user_that_locked_thread(
+        action,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        if not action(thread, commit=False, request=request):
+            return False
+
+        if request:
+            thread.plugin_data["locked_by"] = request.user.id
+
+        if commit:
+            thread.save()
+
+        return True
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: LockThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        return super().__call__(
+            action,
+            thread,
+            commit,
+            request,
+        )
+
+
+lock_thread_hook = LockThreadHook()

--- a/misago/threads/hooks/pin_thread_globally.py
+++ b/misago/threads/hooks/pin_thread_globally.py
@@ -6,15 +6,15 @@ from ...plugins.hooks import FilterHook
 from ..models import Thread
 
 
-class HideThreadHookAction(Protocol):
+class PinThreadGloballyHookAction(Protocol):
     """
-    Misago function for hiding a thread.
+    Misago function for pinning a thread globally.
 
     # Arguments
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to pin globally.
 
     ## `commit: bool = True`
 
@@ -28,7 +28,7 @@ class HideThreadHookAction(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was pinned, `False` otherwise.
     """
 
     def __call__(
@@ -39,13 +39,13 @@ class HideThreadHookAction(Protocol):
     ) -> bool: ...
 
 
-class HideThreadHookFilter(Protocol):
+class PinThreadGloballyHookFilter(Protocol):
     """
     A function implemented by a plugin that can be registered in this hook.
 
     # Arguments
 
-    ## `action: HideThreadHookAction`
+    ## `action: PinThreadGloballyHookAction`
 
     Next function registered in this hook, either a custom function or
     Misago's standard one.
@@ -54,7 +54,7 @@ class HideThreadHookFilter(Protocol):
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to pin globally.
 
     ## `commit: bool = True`
 
@@ -68,40 +68,40 @@ class HideThreadHookFilter(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was pinned, `False` otherwise.
     """
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: PinThreadGloballyHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
     ) -> bool: ...
 
 
-class HideThreadHook(
+class PinThreadGloballyHook(
     FilterHook[
-        HideThreadHookAction,
-        HideThreadHookFilter,
+        PinThreadGloballyHookAction,
+        PinThreadGloballyHookFilter,
     ]
 ):
     """
     This hook allows plugins to replace or extend the logic used to
-    hide a thread.
+    pin a thread globally.
 
     # Example
 
-    Register user who hid the thread.
+    Register user who pinned the thread.
 
     ```python
     from django.http import HttpRequest
-    from misago.threads.hooks import hide_thread_hook
+    from misago.threads.hooks import pin_thread_globally_hook
     from misago.threads.models import Thread
 
 
-    @hide_thread_hook.append_filter
-    def register_user_that_hid_thread(
+    @pin_thread_globally_hook.append_filter
+    def register_user_that_pinned_thread_globally(
         action,
         thread: Thread,
         commit: bool = True,
@@ -111,7 +111,7 @@ class HideThreadHook(
             return False
 
         if request:
-            thread.plugin_data["hidden_by"] = request.user.id
+            thread.plugin_data["pinned_globally_by"] = request.user.id
 
         if commit:
             thread.save()
@@ -123,7 +123,7 @@ class HideThreadHook(
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: PinThreadGloballyHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
@@ -136,4 +136,4 @@ class HideThreadHook(
         )
 
 
-hide_thread_hook = HideThreadHook()
+pin_thread_globally_hook = PinThreadGloballyHook()

--- a/misago/threads/hooks/pin_thread_in_category.py
+++ b/misago/threads/hooks/pin_thread_in_category.py
@@ -6,15 +6,15 @@ from ...plugins.hooks import FilterHook
 from ..models import Thread
 
 
-class HideThreadHookAction(Protocol):
+class PinThreadInCategoryHookAction(Protocol):
     """
-    Misago function for hiding a thread.
+    Misago function for pinning a thread in a category.
 
     # Arguments
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to pin in a category.
 
     ## `commit: bool = True`
 
@@ -28,7 +28,7 @@ class HideThreadHookAction(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was pinned, `False` otherwise.
     """
 
     def __call__(
@@ -39,13 +39,13 @@ class HideThreadHookAction(Protocol):
     ) -> bool: ...
 
 
-class HideThreadHookFilter(Protocol):
+class PinThreadInCategoryHookFilter(Protocol):
     """
     A function implemented by a plugin that can be registered in this hook.
 
     # Arguments
 
-    ## `action: HideThreadHookAction`
+    ## `action: PinThreadInCategoryHookAction`
 
     Next function registered in this hook, either a custom function or
     Misago's standard one.
@@ -54,7 +54,7 @@ class HideThreadHookFilter(Protocol):
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to pin in a category.
 
     ## `commit: bool = True`
 
@@ -68,40 +68,40 @@ class HideThreadHookFilter(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was pinned, `False` otherwise.
     """
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: PinThreadInCategoryHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
     ) -> bool: ...
 
 
-class HideThreadHook(
+class PinThreadInCategoryHook(
     FilterHook[
-        HideThreadHookAction,
-        HideThreadHookFilter,
+        PinThreadInCategoryHookAction,
+        PinThreadInCategoryHookFilter,
     ]
 ):
     """
     This hook allows plugins to replace or extend the logic used to
-    hide a thread.
+    pin a thread in a category.
 
     # Example
 
-    Register user who hid the thread.
+    Register user who pinned the thread.
 
     ```python
     from django.http import HttpRequest
-    from misago.threads.hooks import hide_thread_hook
+    from misago.threads.hooks import pin_thread_in_category_hook
     from misago.threads.models import Thread
 
 
-    @hide_thread_hook.append_filter
-    def register_user_that_hid_thread(
+    @pin_thread_in_category_hook.append_filter
+    def register_user_that_pinned_thread_in_category(
         action,
         thread: Thread,
         commit: bool = True,
@@ -111,7 +111,7 @@ class HideThreadHook(
             return False
 
         if request:
-            thread.plugin_data["hidden_by"] = request.user.id
+            thread.plugin_data["pinned_in_category_by"] = request.user.id
 
         if commit:
             thread.save()
@@ -123,7 +123,7 @@ class HideThreadHook(
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: PinThreadInCategoryHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
@@ -136,4 +136,4 @@ class HideThreadHook(
         )
 
 
-hide_thread_hook = HideThreadHook()
+pin_thread_in_category_hook = PinThreadInCategoryHook()

--- a/misago/threads/hooks/unhide_thread.py
+++ b/misago/threads/hooks/unhide_thread.py
@@ -1,0 +1,139 @@
+from typing import Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ..models import Thread
+
+
+class UnhideThreadHookAction(Protocol):
+    """
+    Misago function for unhiding a thread.
+
+    # Arguments
+
+    ## `thread: Thread`
+
+    A `Thread` to unhide.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was unhidden, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class UnhideThreadHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: UnhideThreadHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `thread: Thread`
+
+    A `Thread` to unhide.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was unhidden, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        action: UnhideThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class UnhideThreadHook(
+    FilterHook[
+        UnhideThreadHookAction,
+        UnhideThreadHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the logic used to
+    unhide a thread.
+
+    # Example
+
+    Register information about user who unhidden the thread
+
+    ```python
+    from django.http import HttpRequest
+    from misago.threads.hooks import unhide_thread_hook
+    from misago.threads.models import Thread
+
+
+    @unhide_thread_hook.append_filter
+    def register_user_that_unhidden_thread(
+        action,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        if not action(thread, commit=False, request=request):
+            return False
+
+        if request:
+            thread.plugin_data["unhidden_by"] = request.user.id
+
+        if commit:
+            thread.save()
+
+        return True
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: UnhideThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        return super().__call__(
+            action,
+            thread,
+            commit,
+            request,
+        )
+
+
+unhide_thread_hook = UnhideThreadHook()

--- a/misago/threads/hooks/unhide_thread.py
+++ b/misago/threads/hooks/unhide_thread.py
@@ -92,7 +92,7 @@ class UnhideThreadHook(
 
     # Example
 
-    Register information about user who unhidden the thread
+    Register user who unhidden the thread.
 
     ```python
     from django.http import HttpRequest

--- a/misago/threads/hooks/unlock_thread.py
+++ b/misago/threads/hooks/unlock_thread.py
@@ -1,0 +1,139 @@
+from typing import Protocol
+
+from django.http import HttpRequest
+
+from ...plugins.hooks import FilterHook
+from ..models import Thread
+
+
+class UnlockThreadHookAction(Protocol):
+    """
+    Misago function for unlocking a thread.
+
+    # Arguments
+
+    ## `thread: Thread`
+
+    A `Thread` to unlock.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was unlocked, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class UnlockThreadHookFilter(Protocol):
+    """
+    A function implemented by a plugin that can be registered in this hook.
+
+    # Arguments
+
+    ## `action: UnlockThreadHookAction`
+
+    Next function registered in this hook, either a custom function or
+    Misago's standard one.
+
+    See the [action](#action) section for details.
+
+    ## `thread: Thread`
+
+    A `Thread` to unlock.
+
+    ## `commit: bool = True`
+
+    Whether the updated thread instance should be saved to the database.
+
+    Defaults to `True`.
+
+    ## `request: HttpRequest | None`
+
+    The request object, or `None` if not provided.
+
+    # Return value
+
+    `True` if the thread was unlocked, `False` otherwise.
+    """
+
+    def __call__(
+        self,
+        action: UnlockThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool: ...
+
+
+class UnlockThreadHook(
+    FilterHook[
+        UnlockThreadHookAction,
+        UnlockThreadHookFilter,
+    ]
+):
+    """
+    This hook allows plugins to replace or extend the logic used to
+    unlock a thread.
+
+    # Example
+
+    Register information about user who unlocked the thread
+
+    ```python
+    from django.http import HttpRequest
+    from misago.threads.hooks import unlock_thread_hook
+    from misago.threads.models import Thread
+
+
+    @unlock_thread_hook.append_filter
+    def register_user_that_unlocked_thread(
+        action,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        if not action(thread, commit=False, request=request):
+            return False
+
+        if request:
+            thread.plugin_data["unlocked_by"] = request.user.id
+
+        if commit:
+            thread.save()
+
+        return True
+    """
+
+    __slots__ = FilterHook.__slots__
+
+    def __call__(
+        self,
+        action: UnlockThreadHookAction,
+        thread: Thread,
+        commit: bool = True,
+        request: HttpRequest | None = None,
+    ) -> bool:
+        return super().__call__(
+            action,
+            thread,
+            commit,
+            request,
+        )
+
+
+unlock_thread_hook = UnlockThreadHook()

--- a/misago/threads/hooks/unlock_thread.py
+++ b/misago/threads/hooks/unlock_thread.py
@@ -92,7 +92,7 @@ class UnlockThreadHook(
 
     # Example
 
-    Register information about user who unlocked the thread
+    Register user who unlocked the thread.
 
     ```python
     from django.http import HttpRequest

--- a/misago/threads/hooks/unpin_thread.py
+++ b/misago/threads/hooks/unpin_thread.py
@@ -6,15 +6,15 @@ from ...plugins.hooks import FilterHook
 from ..models import Thread
 
 
-class HideThreadHookAction(Protocol):
+class UnpinThreadHookAction(Protocol):
     """
-    Misago function for hiding a thread.
+    Misago function for unpinning a thread.
 
     # Arguments
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to unpin.
 
     ## `commit: bool = True`
 
@@ -28,7 +28,7 @@ class HideThreadHookAction(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was unpinned, `False` otherwise.
     """
 
     def __call__(
@@ -39,13 +39,13 @@ class HideThreadHookAction(Protocol):
     ) -> bool: ...
 
 
-class HideThreadHookFilter(Protocol):
+class UnpinThreadHookFilter(Protocol):
     """
     A function implemented by a plugin that can be registered in this hook.
 
     # Arguments
 
-    ## `action: HideThreadHookAction`
+    ## `action: UnpinThreadHookAction`
 
     Next function registered in this hook, either a custom function or
     Misago's standard one.
@@ -54,7 +54,7 @@ class HideThreadHookFilter(Protocol):
 
     ## `thread: Thread`
 
-    A `Thread` to hide.
+    A `Thread` to unpin.
 
     ## `commit: bool = True`
 
@@ -68,40 +68,40 @@ class HideThreadHookFilter(Protocol):
 
     # Return value
 
-    `True` if the thread was hidden, `False` otherwise.
+    `True` if the thread was unpinned, `False` otherwise.
     """
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: UnpinThreadHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
     ) -> bool: ...
 
 
-class HideThreadHook(
+class UnpinThreadHook(
     FilterHook[
-        HideThreadHookAction,
-        HideThreadHookFilter,
+        UnpinThreadHookAction,
+        UnpinThreadHookFilter,
     ]
 ):
     """
     This hook allows plugins to replace or extend the logic used to
-    hide a thread.
+    unpin a thread.
 
     # Example
 
-    Register user who hid the thread.
+    Register user who unpinned the thread.
 
     ```python
     from django.http import HttpRequest
-    from misago.threads.hooks import hide_thread_hook
+    from misago.threads.hooks import unpin_thread_hook
     from misago.threads.models import Thread
 
 
-    @hide_thread_hook.append_filter
-    def register_user_that_hid_thread(
+    @unpin_thread_hook.append_filter
+    def register_user_that_unpinned_thread(
         action,
         thread: Thread,
         commit: bool = True,
@@ -111,7 +111,7 @@ class HideThreadHook(
             return False
 
         if request:
-            thread.plugin_data["hidden_by"] = request.user.id
+            thread.plugin_data["unpinned_by"] = request.user.id
 
         if commit:
             thread.save()
@@ -123,7 +123,7 @@ class HideThreadHook(
 
     def __call__(
         self,
-        action: HideThreadHookAction,
+        action: UnpinThreadHookAction,
         thread: Thread,
         commit: bool = True,
         request: HttpRequest | None = None,
@@ -136,4 +136,4 @@ class HideThreadHook(
         )
 
 
-hide_thread_hook = HideThreadHook()
+unpin_thread_hook = UnpinThreadHook()

--- a/misago/threads/lock.py
+++ b/misago/threads/lock.py
@@ -1,16 +1,19 @@
+from django.http import HttpRequest
+
+from .hooks import lock_thread_hook, unlock_thread_hook
 from .models import Thread
 
 
 def lock_thread(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    return _lock_thread_action(thread, commit, request)
+    return lock_thread_hook(_lock_thread_action, thread, commit, request)
 
 
 def _lock_thread_action(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    if not thread.is_locked:
+    if thread.is_locked:
         return False
 
     thread.is_locked = True
@@ -24,13 +27,13 @@ def _lock_thread_action(
 def unlock_thread(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    return _unlock_thread_action(thread, commit, request)
+    return unlock_thread_hook(_unlock_thread_action, thread, commit, request)
 
 
 def _unlock_thread_action(
     thread: Thread, commit: bool = True, request: HttpRequest | None = None
 ) -> bool:
-    if thread.is_locked:
+    if not thread.is_locked:
         return False
 
     thread.is_locked = False

--- a/misago/threads/lock.py
+++ b/misago/threads/lock.py
@@ -1,0 +1,41 @@
+from .models import Thread
+
+
+def lock_thread(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return _lock_thread_action(thread, commit, request)
+
+
+def _lock_thread_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if not thread.is_locked:
+        return False
+
+    thread.is_locked = True
+
+    if commit:
+        thread.save()
+
+    return True
+
+
+def unlock_thread(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return _unlock_thread_action(thread, commit, request)
+
+
+def _unlock_thread_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if thread.is_locked:
+        return False
+
+    thread.is_locked = False
+
+    if commit:
+        thread.save()
+
+    return True

--- a/misago/threads/pin.py
+++ b/misago/threads/pin.py
@@ -1,0 +1,73 @@
+from django.http import HttpRequest
+
+from .enums import ThreadWeight
+from .hooks import (
+    pin_thread_globally_hook,
+    pin_thread_in_category_hook,
+    unpin_thread_hook,
+)
+from .models import Thread
+
+
+def pin_thread_globally(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return pin_thread_globally_hook(
+        _pin_thread_globally_action, thread, commit, request
+    )
+
+
+def _pin_thread_globally_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if thread.weight == ThreadWeight.PINNED_GLOBALLY:
+        return False
+
+    thread.weight = ThreadWeight.PINNED_GLOBALLY
+
+    if commit:
+        thread.save()
+
+    return True
+
+
+def pin_thread_in_category(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return pin_thread_in_category_hook(
+        _pin_thread_in_category_action, thread, commit, request
+    )
+
+
+def _pin_thread_in_category_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if thread.weight == ThreadWeight.PINNED_IN_CATEGORY:
+        return False
+
+    thread.weight = ThreadWeight.PINNED_IN_CATEGORY
+
+    if commit:
+        thread.save()
+
+    return True
+
+
+def unpin_thread(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    return unpin_thread_hook(_unpin_thread_action, thread, commit, request)
+
+
+def _unpin_thread_action(
+    thread: Thread, commit: bool = True, request: HttpRequest | None = None
+) -> bool:
+    if thread.weight == ThreadWeight.NOT_PINNED:
+        return False
+
+    thread.weight = ThreadWeight.NOT_PINNED
+
+    if commit:
+        thread.save()
+
+    return True

--- a/misago/threads/tests/test_hide.py
+++ b/misago/threads/tests/test_hide.py
@@ -1,0 +1,66 @@
+from ..hide import hide_thread, unhide_thread
+
+
+def test_hide_thread_hides_thread(thread):
+    assert hide_thread(thread)
+    assert thread.is_hidden
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
+def test_hide_thread_doesnt_hide_hidden_thread(django_assert_num_queries, thread):
+    thread.is_hidden = True
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert not hide_thread(thread)
+        assert thread.is_hidden
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
+def test_hide_thread_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    with django_assert_num_queries(0):
+        assert hide_thread(thread, commit=False)
+        assert thread.is_hidden
+
+    thread.refresh_from_db()
+    assert not thread.is_hidden
+
+
+def test_unhide_thread_unhides_thread(thread):
+    thread.is_hidden = True
+    thread.save()
+
+    assert unhide_thread(thread)
+    assert not thread.is_hidden
+
+    thread.refresh_from_db()
+    assert not thread.is_hidden
+
+
+def test_unhide_thread_doesnt_unhide_unhidden_thread(django_assert_num_queries, thread):
+    with django_assert_num_queries(0):
+        assert not unhide_thread(thread)
+        assert not thread.is_hidden
+
+    thread.refresh_from_db()
+    assert not thread.is_hidden
+
+
+def test_unhide_thread_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    thread.is_hidden = True
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert unhide_thread(thread, commit=False)
+        assert not thread.is_hidden
+
+    thread.refresh_from_db()
+    assert thread.is_hidden

--- a/misago/threads/tests/test_lock.py
+++ b/misago/threads/tests/test_lock.py
@@ -1,0 +1,66 @@
+from ..lock import lock_thread, unlock_thread
+
+
+def test_lock_thread_locks_thread(thread):
+    assert lock_thread(thread)
+    assert thread.is_locked
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_lock_thread_doesnt_lock_locked_thread(django_assert_num_queries, thread):
+    thread.is_locked = True
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert not lock_thread(thread)
+        assert thread.is_locked
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_lock_thread_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    with django_assert_num_queries(0):
+        assert lock_thread(thread, commit=False)
+        assert thread.is_locked
+
+    thread.refresh_from_db()
+    assert not thread.is_locked
+
+
+def test_unlock_thread_unlocks_thread(thread):
+    thread.is_locked = True
+    thread.save()
+
+    assert unlock_thread(thread)
+    assert not thread.is_locked
+
+    thread.refresh_from_db()
+    assert not thread.is_locked
+
+
+def test_unlock_thread_doesnt_unlock_unlocked_thread(django_assert_num_queries, thread):
+    with django_assert_num_queries(0):
+        assert not unlock_thread(thread)
+        assert not thread.is_locked
+
+    thread.refresh_from_db()
+    assert not thread.is_locked
+
+
+def test_unlock_thread_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    thread.is_locked = True
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert unlock_thread(thread, commit=False)
+        assert not thread.is_locked
+
+    thread.refresh_from_db()
+    assert thread.is_locked

--- a/misago/threads/tests/test_pin.py
+++ b/misago/threads/tests/test_pin.py
@@ -1,0 +1,139 @@
+from ..enums import ThreadWeight
+from ..pin import (
+    pin_thread_globally,
+    pin_thread_in_category,
+    unpin_thread,
+)
+
+
+def test_pin_thread_globally_pins_unpinned_thread(thread):
+    assert pin_thread_globally(thread)
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+
+def test_pin_thread_globally_pins_pinned_in_category_thread(thread):
+    thread.weight = ThreadWeight.PINNED_IN_CATEGORY
+    thread.save()
+
+    assert pin_thread_globally(thread)
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+
+def test_pin_thread_globally_doesnt_pin_globally_pinned_thread(
+    django_assert_num_queries, thread
+):
+    thread.weight = ThreadWeight.PINNED_GLOBALLY
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert not pin_thread_globally(thread)
+        assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+
+def test_pin_thread_globally_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    with django_assert_num_queries(0):
+        assert pin_thread_globally(thread, commit=False)
+        assert thread.weight == ThreadWeight.PINNED_GLOBALLY
+
+    thread.refresh_from_db()
+    assert thread.weight != ThreadWeight.PINNED_GLOBALLY
+
+
+def test_pin_thread_in_category_pins_unpinned_thread(thread):
+    assert pin_thread_in_category(thread)
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+
+def test_pin_thread_in_category_pins_pinned_globally_thread(thread):
+    thread.weight = ThreadWeight.PINNED_GLOBALLY
+    thread.save()
+
+    assert pin_thread_in_category(thread)
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+
+def test_pin_thread_in_category_doesnt_pin_in_category_pinned_thread(
+    django_assert_num_queries, thread
+):
+    thread.weight = ThreadWeight.PINNED_IN_CATEGORY
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert not pin_thread_in_category(thread)
+        assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+
+def test_pin_thread_in_category_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    with django_assert_num_queries(0):
+        assert pin_thread_in_category(thread, commit=False)
+        assert thread.weight == ThreadWeight.PINNED_IN_CATEGORY
+
+    thread.refresh_from_db()
+    assert thread.weight != ThreadWeight.PINNED_IN_CATEGORY
+
+
+def test_unpin_thread_unpins_globally_pinned_thread(thread):
+    thread.weight = ThreadWeight.PINNED_GLOBALLY
+    thread.save()
+
+    assert unpin_thread(thread)
+    assert thread.weight == ThreadWeight.NOT_PINNED
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.NOT_PINNED
+
+
+def test_unpin_thread_unpins_pinned_in_category_thread(thread):
+    thread.weight = ThreadWeight.PINNED_IN_CATEGORY
+    thread.save()
+
+    assert unpin_thread(thread)
+    assert thread.weight == ThreadWeight.NOT_PINNED
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.NOT_PINNED
+
+
+def test_unpin_thread_doesnt_unpin_unpinned_thread(django_assert_num_queries, thread):
+    with django_assert_num_queries(0):
+        assert not unpin_thread(thread)
+        assert thread.weight == ThreadWeight.NOT_PINNED
+
+    thread.refresh_from_db()
+    assert thread.weight == ThreadWeight.NOT_PINNED
+
+
+def test_unpin_thread_doesnt_save_thread_if_commit_is_false(
+    django_assert_num_queries, thread
+):
+    thread.weight = ThreadWeight.PINNED_IN_CATEGORY
+    thread.save()
+
+    with django_assert_num_queries(0):
+        assert unpin_thread(thread, commit=False)
+        assert thread.weight == ThreadWeight.NOT_PINNED
+
+    thread.refresh_from_db()
+    assert thread.weight != ThreadWeight.NOT_PINNED


### PR DESCRIPTION
Adds pin, hide and lock options to start thread forms for moderators. Updates start thread forms to include them.

Part of the #2056 epic

Fixes #1747

# TODO

- [x] Lock thread function
- [x] Unlock thread function
- [x] Hide thread function
- [x] Unhide thread function
- [x] Pin thread globally function
- [x] Pin thread in category function
- [x] Unpin thread function
- [x] Show moderation actions on start thread page
- [x] Show moderation actions on start private thread page
