### PR TITLE
[Theme] Remove blue outline on clicked anchor links

### DIFF
--- a/frontend/src/style/flavor/typo.less
+++ b/frontend/src/style/flavor/typo.less
@@ -7,6 +7,10 @@ abbr {
   text-decoration: none;
 }
 
+a {
+  outline: none;
+}
+
 .text-danger {
   color: @state-danger-text !important;
 }


### PR DESCRIPTION
## Summary

Chrome applies a blue focus outline on anchor links when clicked. This adds `outline: none` to anchor elements to remove the blue outline, matching the existing pattern used for `abbr` elements in the same file.

## Related Issue

Closes #2091

## Type of Change

- [x] Bug fix (non-breaking change)

## Checklist

- [x] My code follows the existing style.
- [x] CI is green (passing all checks).