### PR TITLE
Copy tweaks

### DIFF
--- a/misago/moderation/post.py
+++ b/misago/moderation/post.py
@@ -204,7 +204,7 @@ class HidePostModerationAction(FormMixin, PostModerationAction):
             raise ValidationError(
                 pgettext(
                     "post moderation validation",
-                    "The thread's original post can't be hidden.",
+                    "Thread's first post can't be hidden.",
                 )
             )
 
@@ -317,7 +317,7 @@ class SplitPostModerationAction(FormMixin, PostModerationAction):
             raise ValidationError(
                 pgettext(
                     "post moderation validation",
-                    "The first post in a thread can't be split.",
+                    "Thread's first post can't be split.",
                 )
             )
 
@@ -396,7 +396,7 @@ class MovePostModerationAction(FormMixin, PostModerationAction):
             raise ValidationError(
                 pgettext(
                     "post moderation validation",
-                    "The first post in a thread can't be split.",
+                    "Thread's first post can't be moved.",
                 )
             )
 
@@ -606,7 +606,7 @@ class DeletePostModerationAction(ConfirmMixin, PostModerationAction):
     button_label = "Delete"
     confirmation_message = pgettext_lazy(
         "post moderation",
-        "Are you sure you want to delete this post? This action cannot be undone.",
+        "Are you sure you want to delete this post? This can't be undone.",
     )
 
     def validate(self):
@@ -614,7 +614,7 @@ class DeletePostModerationAction(ConfirmMixin, PostModerationAction):
             raise ValidationError(
                 pgettext(
                     "post moderation validation",
-                    "First post in a thread can't be deleted.",
+                    "Thread's first post can't be deleted.",
                 )
             )
 

--- a/misago/moderation/posts.py
+++ b/misago/moderation/posts.py
@@ -178,7 +178,7 @@ class HidePostsModerationAction(FormMixin, PostsModerationAction):
                 raise ValidationError(
                     pgettext(
                         "posts moderation validation",
-                        "Thread's original post can't be hidden.",
+                        "Thread's first post can't be hidden.",
                     )
                 )
 
@@ -290,7 +290,7 @@ class SplitPostsModerationAction(FormMixin, PostsModerationAction):
                 raise ValidationError(
                     pgettext(
                         "post moderation validation",
-                        "The first post in a thread can't be split.",
+                        "Thread's first post can't be split.",
                     )
                 )
 
@@ -372,7 +372,7 @@ class MovePostsModerationAction(FormMixin, PostsModerationAction):
                 raise ValidationError(
                     pgettext(
                         "post moderation validation",
-                        "The first post in a thread can't be moved.",
+                        "Thread's first post can't be moved.",
                     )
                 )
 
@@ -540,7 +540,7 @@ class DeletePostsModerationAction(ConfirmMixin, PostsModerationAction):
     button_label = "Delete"
     confirmation_message = pgettext_lazy(
         "posts moderation",
-        "Are you sure you want to delete the selected posts? This action cannot be undone.",
+        "Are you sure you want to delete the selected posts? This can't be undone.",
     )
 
     def validate(self):
@@ -549,7 +549,7 @@ class DeletePostsModerationAction(ConfirmMixin, PostsModerationAction):
                 raise ValidationError(
                     pgettext(
                         "posts moderation validation",
-                        "The first post in a thread can't be deleted.",
+                        "Thread's first post can't be deleted.",
                     )
                 )
 

--- a/misago/moderation/thread.py
+++ b/misago/moderation/thread.py
@@ -583,7 +583,7 @@ class DeleteThreadModerationAction(ConfirmMixin, ThreadModerationAction):
     button_label = "Delete"
     confirmation_message = pgettext_lazy(
         "thread moderation",
-        "Are you sure you want to delete this thread? This action cannot be undone.",
+        "Are you sure you want to delete this thread? This can't be undone.",
     )
 
     def confirmed(self) -> ModerationResult:

--- a/misago/moderation/threads.py
+++ b/misago/moderation/threads.py
@@ -609,7 +609,7 @@ class DeleteThreadsModerationAction(ConfirmMixin, ThreadsModerationAction):
     button_label = "Delete"
     confirmation_message = pgettext_lazy(
         "threads moderation",
-        "Are you sure you want to delete the selected threads? This action cannot be undone.",
+        "Are you sure you want to delete the selected threads? This can't be undone.",
     )
 
     def confirmed(self) -> ModerationResult:

--- a/misago/privatethreads/tests/test_private_thread_detail_view_moderation_actions.py
+++ b/misago/privatethreads/tests/test_private_thread_detail_view_moderation_actions.py
@@ -510,7 +510,7 @@ def test_private_thread_detail_view_hide_posts_moderation_action_validates_first
         ),
         {"posts_moderation": "hide", "posts": [user_private_thread.first_post_id]},
     )
-    assert_contains(response, "Thread&#x27;s original post can&#x27;t be hidden.")
+    assert_contains(response, "Thread&#x27;s first post can&#x27;t be hidden.")
 
 
 def test_private_thread_detail_view_unhide_posts_moderation_action_unhides_posts(
@@ -1189,7 +1189,7 @@ def test_private_thread_detail_view_delete_posts_moderation_action_validates_fir
         ),
         {"posts_moderation": "delete", "posts": [user_private_thread.first_post_id]},
     )
-    assert_contains(response, "The first post in a thread can&#x27;t be deleted.")
+    assert_contains(response, "Thread&#x27;s first post can&#x27;t be deleted.")
 
     user_private_thread.first_post.refresh_from_db()
 

--- a/misago/threads/tests/test_thread_detail_view_moderation_actions.py
+++ b/misago/threads/tests/test_thread_detail_view_moderation_actions.py
@@ -1584,7 +1584,7 @@ def test_thread_detail_view_hide_posts_moderation_action_validates_first_post(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
         {"posts_moderation": "hide", "posts": [thread.first_post_id]},
     )
-    assert_contains(response, "Thread&#x27;s original post can&#x27;t be hidden.")
+    assert_contains(response, "Thread&#x27;s first post can&#x27;t be hidden.")
 
 
 def test_thread_detail_view_unhide_posts_moderation_action_unhides_posts(
@@ -1894,7 +1894,7 @@ def test_thread_detail_view_split_posts_moderation_action_validates_first_post(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
         {"posts_moderation": "split", "posts": [thread.first_post_id]},
     )
-    assert_contains(response, "The first post in a thread can&#x27;t be split.")
+    assert_contains(response, "Thread&#x27;s first post can&#x27;t be split.")
 
 
 def test_thread_detail_view_split_posts_moderation_action_validates_category_value(
@@ -3115,7 +3115,7 @@ def test_thread_detail_view_delete_posts_moderation_action_validates_first_post(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
         {"posts_moderation": "delete", "posts": [thread.first_post_id]},
     )
-    assert_contains(response, "The first post in a thread can&#x27;t be deleted.")
+    assert_contains(response, "Thread&#x27;s first post can&#x27;t be deleted.")
 
     thread.first_post.refresh_from_db()
 


### PR DESCRIPTION
Unifies semantics around "first post" and makes confirmation actions messages shorter.

Part of the #1789 epic