### PR TITLE
Moderation tests cleanup

### DIFF
--- a/misago/privatethreads/tests/test_private_thread_detail_view_moderation.py
+++ b/misago/privatethreads/tests/test_private_thread_detail_view_moderation.py
@@ -70,6 +70,21 @@ def test_private_thread_detail_view_shows_posts_moderation_form_to_private_threa
     assert_contains(response, POSTS_MODERATION_FORM_HTML)
 
 
+def test_private_thread_detail_view_shows_posts_moderation_form_to_global_moderator(
+    moderator_client, user_private_thread
+):
+    response = moderator_client.get(
+        reverse(
+            "misago:private-thread",
+            kwargs={
+                "thread_id": user_private_thread.id,
+                "slug": user_private_thread.slug,
+            },
+        )
+    )
+    assert_contains(response, POSTS_MODERATION_FORM_HTML)
+
+
 def test_private_thread_detail_view_shows_posts_checkboxes_to_private_threads_moderator(
     user_client, user, user_private_thread
 ):
@@ -104,21 +119,6 @@ def test_private_thread_detail_view_shows_posts_checkboxes_to_global_moderator(
         )
     )
     assert_contains(response, POSTS_CHECKBOX_HTML)
-
-
-def test_private_thread_detail_view_shows_posts_moderation_form_to_global_moderator(
-    moderator_client, user_private_thread
-):
-    response = moderator_client.get(
-        reverse(
-            "misago:private-thread",
-            kwargs={
-                "thread_id": user_private_thread.id,
-                "slug": user_private_thread.slug,
-            },
-        )
-    )
-    assert_contains(response, POSTS_MODERATION_FORM_HTML)
 
 
 def test_private_thread_detail_view_shows_fixed_posts_moderation_form_to_private_threads_moderator(

--- a/misago/privatethreads/tests/test_private_thread_detail_view_moderation_actions.py
+++ b/misago/privatethreads/tests/test_private_thread_detail_view_moderation_actions.py
@@ -33,7 +33,7 @@ def mock_post_notify_on_new_thread_reply(mocker):
     return mocker.patch("misago.moderation.post.notify_on_new_thread_reply")
 
 
-def test_private_thread_detail_view_executes_lock_thread_moderation_action(
+def test_private_thread_detail_view_lock_thread_moderation_action_locks_thread(
     moderator_client, user_private_thread
 ):
     response = moderator_client.post(
@@ -65,7 +65,7 @@ def test_private_thread_detail_view_executes_lock_thread_moderation_action(
     )
 
 
-def test_private_thread_detail_view_executes_unlock_thread_moderation_action(
+def test_private_thread_detail_view_unlock_thread_moderation_action_unlocks_thread(
     moderator_client, user_private_thread
 ):
     user_private_thread.is_locked = True
@@ -100,7 +100,7 @@ def test_private_thread_detail_view_executes_unlock_thread_moderation_action(
     )
 
 
-def test_private_thread_detail_view_executes_hide_thread_moderation_action(
+def test_private_thread_detail_view_hide_thread_moderation_action_hides_thread(
     moderator_client, moderator, user_private_thread, mock_thread_synchronize_categories
 ):
     response = moderator_client.post(
@@ -155,7 +155,7 @@ def test_private_thread_detail_view_executes_hide_thread_moderation_action(
     )
 
 
-def test_private_thread_detail_view_executes_unhide_thread_moderation_action(
+def test_private_thread_detail_view_unhide_thread_moderation_action_unhides_thread(
     moderator_client, user_private_thread, mock_thread_synchronize_categories
 ):
     user_private_thread.is_hidden = True
@@ -196,7 +196,7 @@ def test_private_thread_detail_view_executes_unhide_thread_moderation_action(
     )
 
 
-def test_private_thread_detail_view_executes_approve_thread_moderation_action(
+def test_private_thread_detail_view_approve_thread_moderation_action_approves_thread(
     mocker,
     moderator_client,
     user,
@@ -245,7 +245,7 @@ def test_private_thread_detail_view_executes_approve_thread_moderation_action(
     )
 
 
-def test_private_thread_detail_view_executes_require_reply_approval_thread_moderation_action(
+def test_private_thread_detail_view_require_reply_approval_thread_moderation_action_sets_thread_require_reply_approval_flag(
     moderator_client, user_private_thread
 ):
     response = moderator_client.post(
@@ -274,7 +274,7 @@ def test_private_thread_detail_view_executes_require_reply_approval_thread_moder
     )
 
 
-def test_private_thread_detail_view_executes_remove_reply_approval_thread_moderation_action(
+def test_private_thread_detail_view_remove_reply_approval_thread_moderation_action_removes_thread_require_reply_approval_flag(
     moderator_client, user_private_thread
 ):
     user_private_thread.require_reply_approval = True
@@ -306,7 +306,7 @@ def test_private_thread_detail_view_executes_remove_reply_approval_thread_modera
     )
 
 
-def test_private_thread_detail_view_executes_delete_thread_moderation_action(
+def test_private_thread_detail_view_delete_thread_moderation_action_deletes_thread(
     moderator_client, user_private_thread, mock_thread_synchronize_categories
 ):
     response = moderator_client.post(
@@ -1198,7 +1198,7 @@ def test_private_thread_detail_view_delete_posts_moderation_action_validates_fir
     mock_posts_synchronize_categories.delay.assert_not_called()
 
 
-def test_private_thread_detail_view_executes_lock_post_moderation_action(
+def test_private_thread_detail_view_lock_post_moderation_action_locks_post(
     thread_reply_factory, moderator_client, user_private_thread
 ):
     reply = thread_reply_factory(user_private_thread)
@@ -1230,7 +1230,7 @@ def test_private_thread_detail_view_executes_lock_post_moderation_action(
     assert reply.is_locked
 
 
-def test_private_thread_detail_view_executes_unlock_post_moderation_action(
+def test_private_thread_detail_view_unlock_post_moderation_action_unlocks_post(
     thread_reply_factory, moderator_client, user_private_thread
 ):
     reply = thread_reply_factory(user_private_thread, is_locked=True)
@@ -1262,7 +1262,7 @@ def test_private_thread_detail_view_executes_unlock_post_moderation_action(
     assert not reply.is_locked
 
 
-def test_private_thread_detail_view_executes_hide_post_moderation_action(
+def test_private_thread_detail_view_hide_post_moderation_action_hides_post(
     thread_reply_factory, moderator_client, moderator, user_private_thread
 ):
     reply = thread_reply_factory(user_private_thread)
@@ -1317,7 +1317,7 @@ def test_private_thread_detail_view_executes_hide_post_moderation_action(
     assert reply.hidden_reason == "Lorem ipsum"
 
 
-def test_private_thread_detail_view_executes_unhide_post_moderation_action(
+def test_private_thread_detail_view_unhide_post_moderation_action_unhides_post(
     thread_reply_factory, moderator_client, user_private_thread
 ):
     reply = thread_reply_factory(user_private_thread, is_hidden=True)
@@ -1354,7 +1354,7 @@ def test_private_thread_detail_view_executes_unhide_post_moderation_action(
     assert reply.hidden_reason is None
 
 
-def test_private_thread_detail_view_executes_approve_post_moderation_action(
+def test_private_thread_detail_view_approve_post_moderation_action_approves_post(
     post_factory,
     moderator_client,
     user_private_thread,

--- a/misago/threads/tests/test_category_thread_list_view_moderation.py
+++ b/misago/threads/tests/test_category_thread_list_view_moderation.py
@@ -10,6 +10,11 @@ MODERATION_FIXED_HTML = '<div class="fixed-moderation">'
 DISABLED_CHECKBOX_HTML = '<input type="checkbox" disabled />'
 
 
+@pytest.fixture
+def mock_synchronize_categories(mocker):
+    return mocker.patch("misago.moderation.threads.synchronize_categories")
+
+
 def test_category_thread_list_view_shows_noscript_moderation_form_to_category_moderator(
     user_client, user, default_category
 ):
@@ -123,7 +128,7 @@ def test_category_thread_list_view_shows_disabled_threads_checkboxes_to_other_ca
     assert_contains(response, DISABLED_CHECKBOX_HTML)
 
 
-def test_category_thread_list_view_executes_single_stage_moderation_action(
+def test_category_thread_list_view_executes_moderation_action(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -139,7 +144,7 @@ def test_category_thread_list_view_executes_single_stage_moderation_action(
     assert thread.is_locked
 
 
-def test_category_thread_list_view_executes_single_stage_moderation_action_in_htmx(
+def test_category_thread_list_view_executes_moderation_action_in_htmx(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -157,23 +162,98 @@ def test_category_thread_list_view_executes_single_stage_moderation_action_in_ht
     assert thread.is_locked
 
 
-@pytest.mark.xfail(reason="delete thread moderation action not yet implemented")
-def test_category_thread_list_view_executes_moderation_action_with_confirmation(
-    thread_factory, moderator_client, default_category
+def test_category_thread_list_view_executes_moderation_action_with_form(
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
 ):
     thread = thread_factory(default_category)
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
-        {"moderation": "move", "threads": [thread.id]},
+        {"moderation": "hide", "threads": [thread.id]},
     )
-    assert_contains(response, "Delete threads")
-    assert_contains(response, "Are you sure you want to delete selected threads?")
+    assert_contains(response, "Hide threads")
+    assert_contains(response, "Reason for hiding")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-swap" value="outerHTML"'
+    )
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
         {
-            "moderation": "Delete",
+            "moderation": "hide",
+            "threads": [thread.id],
+            "confirm": "true",
+        },
+    )
+    assert response.status_code == 302
+    assert response["location"] == default_category.get_absolute_url()
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
+def test_category_thread_list_view_executes_moderation_action_with_form_in_htmx(
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {"moderation": "hide", "threads": [thread.id]},
+        headers={"hx-request": "true"},
+    )
+    assert_contains(response, "Reason for hiding")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_contains(response, 'type="hidden" name="success-hx-swap" value="outerHTML"')
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "hide",
+            "threads": [thread.id],
+            "confirm": "true",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert_contains(response, thread.title)
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
+def test_category_thread_list_view_executes_moderation_action_with_confirmation(
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {"moderation": "delete", "threads": [thread.id]},
+    )
+    assert_contains(response, "Delete threads")
+    assert_contains(response, "Are you sure you want to delete the selected threads?")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-swap" value="outerHTML"'
+    )
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "delete",
             "threads": [thread.id],
             "confirm": "delete",
         },
@@ -185,9 +265,8 @@ def test_category_thread_list_view_executes_moderation_action_with_confirmation(
         thread.refresh_from_db()
 
 
-@pytest.mark.xfail(reason="delete thread moderation action not yet implemented")
 def test_category_thread_list_view_executes_moderation_action_with_confirmation_in_htmx(
-    thread_factory, moderator_client, default_category
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
 ):
     thread = thread_factory(default_category)
 
@@ -196,8 +275,13 @@ def test_category_thread_list_view_executes_moderation_action_with_confirmation_
         {"moderation": "delete", "threads": [thread.id]},
         headers={"hx-request": "true"},
     )
-    assert_contains(response, "Delete")
-    assert_contains(response, "Are you sure you want to delete selected threads?")
+    assert_contains(response, "Are you sure you want to delete the selected threads?")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_contains(response, 'type="hidden" name="success-hx-swap" value="outerHTML"')
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
@@ -208,68 +292,152 @@ def test_category_thread_list_view_executes_moderation_action_with_confirmation_
         },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, thread.title)
+    assert response.status_code == 200
 
     with pytest.raises(Thread.DoesNotExist):
         thread.refresh_from_db()
 
 
-@pytest.mark.xfail(reason="move thread moderation action not yet implemented")
-def test_category_thread_list_view_executes_moderation_action_with_form(
-    thread_factory, moderator_client, default_category, child_category
+def test_category_thread_list_view_moderation_doesnt_set_htmx_trigger_header_on_success(
+    thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
-        {"moderation": "move", "threads": [thread.id]},
-    )
-    assert_contains(response, "Move threads")
-    assert_contains(response, "Move to")
-
-    response = moderator_client.post(
-        default_category.get_absolute_url(),
         {
-            "moderation": "move",
+            "moderation": "lock",
             "threads": [thread.id],
-            "moderation-category": child_category.id,
-            "confirm": "true",
         },
     )
     assert response.status_code == 302
-    assert response["location"] == default_category.get_absolute_url()
+    assert "hx-trigger" not in response
 
     thread.refresh_from_db()
-    assert thread.category == child_category
+    assert thread.is_locked
 
 
-@pytest.mark.xfail(reason="move thread moderation action not yet implemented")
-def test_category_thread_list_view_executes_moderation_action_with_form_in_htmx(
-    thread_factory, moderator_client, default_category, child_category
+def test_category_thread_list_view_moderation_sets_htmx_trigger_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
-        {"moderation": "move", "threads": [thread.id]},
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+        },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, "Move to")
+    assert response.status_code == 200
+    assert response["hx-trigger"] == "misago:afterModeration"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_category_thread_list_view_moderation_doesnt_set_htmx_retarget_header_on_success(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-target": "#misago-htmx-root",
+        },
+    )
+    assert response.status_code == 302
+    assert "hx-retarget" not in response
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_category_thread_list_view_moderation_sets_htmx_retarget_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-target": "#misago-htmx-root",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert response.status_code == 200
+    assert response["hx-retarget"] == "#misago-htmx-root"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_category_thread_list_view_moderation_doesnt_set_htmx_reswap_header_on_success(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-swap": "outerHTML",
+        },
+    )
+    assert response.status_code == 302
+    assert "hx-reswap" not in response
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_category_thread_list_view_moderation_sets_htmx_reswap_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        default_category.get_absolute_url(),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-swap": "outerHTML",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert response.status_code == 200
+    assert response["hx-reswap"] == "outerHTML"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+def test_category_thread_list_view_moderation_doesnt_set_htmx_headers_on_template_response_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
 
     response = moderator_client.post(
         default_category.get_absolute_url(),
         {
             "moderation": "move",
             "threads": [thread.id],
-            "moderation-category": child_category.id,
-            "confirm": "true",
+            "success-hx-target": "#misago-htmx-root",
+            "success-hx-swap": "outerHTML",
         },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, thread.title)
-
-    thread.refresh_from_db()
-    assert thread.category == child_category
+    assert response.status_code == 200
+    assert "hx-trigger" not in response
+    assert "hx-retarget" not in response
+    assert "hx-reswap" not in response
 
 
 def test_category_thread_list_view_moderation_shows_error_to_user(

--- a/misago/threads/tests/test_category_thread_list_view_moderation_actions.py
+++ b/misago/threads/tests/test_category_thread_list_view_moderation_actions.py
@@ -281,8 +281,8 @@ def test_category_thread_list_view_hide_moderation_action_hides_threads(
         default_category.get_absolute_url(),
         {"moderation": "hide", "threads": [thread.id]},
     )
-    assert_contains(response, "Reason for hiding")
     assert_contains(response, "Hide threads")
+    assert_contains(response, "Reason for hiding")
 
     response = moderator_client.post(
         default_category.get_absolute_url(),

--- a/misago/threads/tests/test_category_thread_list_view_moderation_actions.py
+++ b/misago/threads/tests/test_category_thread_list_view_moderation_actions.py
@@ -22,7 +22,7 @@ def mock_delete_duplicate_watched_threads(mocker):
     return mocker.patch("misago.moderation.threads.delete_duplicate_watched_threads")
 
 
-def test_category_thread_list_view_pin_everywhere_moderation_action_pins_unpinned_thread(
+def test_category_thread_list_view_pin_everywhere_moderation_action_pins_unpinned_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -44,7 +44,7 @@ def test_category_thread_list_view_pin_everywhere_moderation_action_pins_unpinne
     )
 
 
-def test_category_thread_list_view_pin_everywhere_moderation_action_pins_pinned_category_thread(
+def test_category_thread_list_view_pin_everywhere_moderation_action_pins_pinned_category_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.CATEGORY)
@@ -80,7 +80,7 @@ def test_category_thread_list_view_pin_everywhere_moderation_action_validates_th
     assert not ThreadUpdate.objects.exists()
 
 
-def test_category_thread_list_view_pin_category_moderation_action_pins_unpinned_thread(
+def test_category_thread_list_view_pin_category_moderation_action_pins_unpinned_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -102,7 +102,7 @@ def test_category_thread_list_view_pin_category_moderation_action_pins_unpinned_
     )
 
 
-def test_category_thread_list_view_pin_category_moderation_action_pins_pinned_everywhere_thread(
+def test_category_thread_list_view_pin_category_moderation_action_pins_pinned_everywhere_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.EVERYWHERE)
@@ -138,7 +138,7 @@ def test_category_thread_list_view_pin_category_moderation_action_validates_thre
     assert not ThreadUpdate.objects.exists()
 
 
-def test_category_thread_list_view_unpin_moderation_action_unpins_pinned_everywhere_thread(
+def test_category_thread_list_view_unpin_moderation_action_unpins_pinned_everywhere_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.EVERYWHERE)
@@ -160,7 +160,7 @@ def test_category_thread_list_view_unpin_moderation_action_unpins_pinned_everywh
     )
 
 
-def test_category_thread_list_view_unpin_moderation_action_unpins_pinned_category_thread(
+def test_category_thread_list_view_unpin_moderation_action_unpins_pinned_category_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.CATEGORY)
@@ -196,7 +196,7 @@ def test_category_thread_list_view_unpin_moderation_action_validates_threads(
     assert not ThreadUpdate.objects.exists()
 
 
-def test_category_thread_list_view_lock_moderation_action_locks_thread(
+def test_category_thread_list_view_lock_moderation_action_locks_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -232,7 +232,7 @@ def test_category_thread_list_view_lock_moderation_action_validates_threads(
     assert not ThreadUpdate.objects.exists()
 
 
-def test_category_thread_list_view_unlock_moderation_action_unlocks_thread(
+def test_category_thread_list_view_unlock_moderation_action_unlocks_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, is_locked=True)

--- a/misago/threads/tests/test_thread_detail_view_moderation.py
+++ b/misago/threads/tests/test_thread_detail_view_moderation.py
@@ -54,6 +54,15 @@ def test_thread_detail_view_shows_posts_moderation_form_to_category_moderator(
     assert_contains(response, POSTS_MODERATION_FORM_HTML)
 
 
+def test_thread_detail_view_shows_posts_moderation_form_to_global_moderator(
+    moderator_client, thread
+):
+    response = moderator_client.get(
+        reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug})
+    )
+    assert_contains(response, POSTS_MODERATION_FORM_HTML)
+
+
 def test_thread_detail_view_shows_posts_checkboxes_to_category_moderator(
     user_client, user, thread
 ):
@@ -76,15 +85,6 @@ def test_thread_detail_view_shows_posts_checkboxes_to_global_moderator(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug})
     )
     assert_contains(response, POSTS_CHECKBOX_HTML)
-
-
-def test_thread_detail_view_shows_posts_moderation_form_to_global_moderator(
-    moderator_client, thread
-):
-    response = moderator_client.get(
-        reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug})
-    )
-    assert_contains(response, POSTS_MODERATION_FORM_HTML)
 
 
 def test_thread_detail_view_shows_fixed_posts_moderation_form_to_category_moderator(
@@ -215,7 +215,9 @@ def test_thread_detail_view_doesnt_show_post_moderation_form_to_guest(client, th
     assert_not_contains(response, POST_MODERATION_FORM_HTML)
 
 
-def test_thread_detail_view_executes_thread_moderation_action(moderator_client, thread):
+def test_thread_detail_view_executes_one_step_thread_moderation_action(
+    moderator_client, thread
+):
     response = moderator_client.post(
         reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
         {"thread_moderation": "lock"},
@@ -229,7 +231,7 @@ def test_thread_detail_view_executes_thread_moderation_action(moderator_client, 
     assert thread.is_locked
 
 
-def test_thread_detail_view_executes_thread_moderation_action_in_htmx(
+def test_thread_detail_view_executes_one_step_thread_moderation_action_in_htmx(
     moderator_client, thread
 ):
     response = moderator_client.post(

--- a/misago/threads/tests/test_thread_detail_view_moderation_actions.py
+++ b/misago/threads/tests/test_thread_detail_view_moderation_actions.py
@@ -44,7 +44,7 @@ def mock_post_notify_on_new_thread_reply(mocker):
     return mocker.patch("misago.moderation.post.notify_on_new_thread_reply")
 
 
-def test_thread_detail_view_executes_pin_everywhere_thread_moderation_action(
+def test_thread_detail_view_pin_everywhere_thread_moderation_action_pins_unpinned_thread(
     moderator_client, thread
 ):
     response = moderator_client.post(
@@ -66,7 +66,32 @@ def test_thread_detail_view_executes_pin_everywhere_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_pin_category_thread_moderation_action(
+def test_thread_detail_view_pin_everywhere_thread_moderation_action_pins_pinned_category_thread(
+    moderator_client, thread
+):
+    thread.pinned = ThreadPinned.CATEGORY
+    thread.save()
+
+    response = moderator_client.post(
+        reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
+        {"thread_moderation": "pin_everywhere"},
+    )
+    assert response.status_code == 302
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    thread.refresh_from_db()
+    assert thread.pinned == ThreadPinned.EVERYWHERE
+    assert thread.has_updates
+
+    ThreadUpdate.objects.get(
+        thread=thread,
+        action=ThreadUpdateActionName.PINNED_EVERYWHERE,
+    )
+
+
+def test_thread_detail_view_pin_category_thread_moderation_action_pins_unpinned_thread(
     moderator_client, thread
 ):
     response = moderator_client.post(
@@ -88,7 +113,32 @@ def test_thread_detail_view_executes_pin_category_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_unpin_pinned_everywhere_thread_moderation_action(
+def test_thread_detail_view_pin_category_thread_moderation_action_pins_pinned_everywhere_thread(
+    moderator_client, thread
+):
+    thread.pinned = ThreadPinned.EVERYWHERE
+    thread.save()
+
+    response = moderator_client.post(
+        reverse("misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}),
+        {"thread_moderation": "pin_category"},
+    )
+    assert response.status_code == 302
+    assert response["location"] == reverse(
+        "misago:thread", kwargs={"thread_id": thread.id, "slug": thread.slug}
+    )
+
+    thread.refresh_from_db()
+    assert thread.pinned == ThreadPinned.CATEGORY
+    assert thread.has_updates
+
+    ThreadUpdate.objects.get(
+        thread=thread,
+        action=ThreadUpdateActionName.PINNED_CATEGORY,
+    )
+
+
+def test_thread_detail_view_unpin_thread_moderation_action_unpins_pinned_everywhere_thread(
     moderator_client, thread
 ):
     thread.pinned = ThreadPinned.EVERYWHERE
@@ -113,7 +163,7 @@ def test_thread_detail_view_executes_unpin_pinned_everywhere_thread_moderation_a
     )
 
 
-def test_thread_detail_view_executes_unpin_pinned_category_thread_moderation_action(
+def test_thread_detail_view_unpin_thread_moderation_action_unpins_pinned_category_thread(
     moderator_client, thread
 ):
     thread.pinned = ThreadPinned.CATEGORY
@@ -138,7 +188,7 @@ def test_thread_detail_view_executes_unpin_pinned_category_thread_moderation_act
     )
 
 
-def test_thread_detail_view_executes_lock_thread_moderation_action(
+def test_thread_detail_view_lock_thread_moderation_action_locks_thread(
     moderator_client, thread
 ):
     response = moderator_client.post(
@@ -160,7 +210,7 @@ def test_thread_detail_view_executes_lock_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_unlock_thread_moderation_action(
+def test_thread_detail_view_unlock_thread_moderation_action_unlocks_thread(
     moderator_client, thread
 ):
     thread.is_locked = True
@@ -185,7 +235,7 @@ def test_thread_detail_view_executes_unlock_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_hide_thread_moderation_action(
+def test_thread_detail_view_hide_thread_moderation_action_hides_thread(
     moderator_client, moderator, thread, mock_thread_synchronize_categories
 ):
     response = moderator_client.post(
@@ -227,7 +277,7 @@ def test_thread_detail_view_executes_hide_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_unhide_thread_moderation_action(
+def test_thread_detail_view_unhide_thread_moderation_action_unhides_thread(
     moderator_client, thread, mock_thread_synchronize_categories
 ):
     thread.is_hidden = True
@@ -261,7 +311,7 @@ def test_thread_detail_view_executes_unhide_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_approve_thread_moderation_action(
+def test_thread_detail_view_approve_thread_moderation_action_approves_thread(
     moderator_client, thread, mock_thread_synchronize_categories
 ):
     thread.is_unapproved = True
@@ -290,7 +340,7 @@ def test_thread_detail_view_executes_approve_thread_moderation_action(
     )
 
 
-def test_thread_detail_view_executes_require_reply_approval_thread_moderation_action(
+def test_thread_detail_view_require_reply_approval_thread_moderation_action_sets_thread_require_reply_approval_flag(
     moderator_client, thread
 ):
     response = moderator_client.post(
@@ -312,7 +362,7 @@ def test_thread_detail_view_executes_require_reply_approval_thread_moderation_ac
     )
 
 
-def test_thread_detail_view_executes_remove_reply_approval_thread_moderation_action(
+def test_thread_detail_view_remove_reply_approval_thread_moderation_action_removes_thread_require_reply_approval_flag(
     moderator_client, thread
 ):
     thread.require_reply_approval = True
@@ -337,7 +387,7 @@ def test_thread_detail_view_executes_remove_reply_approval_thread_moderation_act
     )
 
 
-def test_thread_detail_view_executes_move_thread_moderation_action(
+def test_thread_detail_view_move_thread_moderation_action_moves_thread(
     thread_factory,
     moderator_client,
     moderators_group,
@@ -1443,7 +1493,7 @@ def test_thread_detail_view_merge_thread_moderation_action_validates_conflict_re
     mock_delete_duplicate_watched_threads.delay.assert_not_called()
 
 
-def test_thread_detail_view_executes_delete_thread_moderation_action(
+def test_thread_detail_view_delete_thread_moderation_action_deletes_thread(
     moderator_client, default_category, thread, mock_thread_synchronize_categories
 ):
     response = moderator_client.post(
@@ -3124,7 +3174,7 @@ def test_thread_detail_view_delete_posts_moderation_action_validates_first_post(
     mock_posts_synchronize_categories.delay.assert_not_called()
 
 
-def test_thread_detail_view_executes_lock_post_moderation_action(
+def test_thread_detail_view_lock_post_moderation_action_locks_post(
     moderator_client, thread, reply
 ):
     response = moderator_client.post(
@@ -3144,7 +3194,7 @@ def test_thread_detail_view_executes_lock_post_moderation_action(
     assert reply.is_locked
 
 
-def test_thread_detail_view_executes_unlock_post_moderation_action(
+def test_thread_detail_view_unlock_post_moderation_action_unlocks_post(
     moderator_client, thread, reply
 ):
     reply.is_locked = True
@@ -3167,7 +3217,7 @@ def test_thread_detail_view_executes_unlock_post_moderation_action(
     assert not reply.is_locked
 
 
-def test_thread_detail_view_executes_hide_post_moderation_action(
+def test_thread_detail_view_hide_post_moderation_action_hides_post(
     moderator_client, moderator, thread, reply
 ):
     response = moderator_client.post(
@@ -3204,7 +3254,7 @@ def test_thread_detail_view_executes_hide_post_moderation_action(
     assert reply.hidden_reason == "Lorem ipsum"
 
 
-def test_thread_detail_view_executes_unhide_post_moderation_action(
+def test_thread_detail_view_unhide_post_moderation_action_unhides_post(
     moderator_client, thread, reply
 ):
     reply.is_hidden = True
@@ -3232,7 +3282,7 @@ def test_thread_detail_view_executes_unhide_post_moderation_action(
     assert reply.hidden_reason is None
 
 
-def test_thread_detail_view_executes_approve_post_moderation_action(
+def test_thread_detail_view_approve_post_moderation_action_approves_post(
     post_factory,
     moderator_client,
     thread,

--- a/misago/threads/tests/test_thread_list_view_moderation.py
+++ b/misago/threads/tests/test_thread_list_view_moderation.py
@@ -11,6 +11,11 @@ MODERATION_FIXED_HTML = '<div class="fixed-moderation">'
 DISABLED_CHECKBOX_HTML = '<input type="checkbox" disabled />'
 
 
+@pytest.fixture
+def mock_synchronize_categories(mocker):
+    return mocker.patch("misago.moderation.threads.synchronize_categories")
+
+
 @override_dynamic_settings(index_view="categories")
 def test_thread_list_view_shows_noscript_moderation_form_to_category_moderator(
     user_client, user, default_category
@@ -151,10 +156,79 @@ def test_thread_list_view_executes_moderation_action_in_htmx(
     assert thread.is_locked
 
 
-@pytest.mark.xfail(reason="delete thread moderation action not yet implemented")
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_executes_moderation_action_with_form(
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {"moderation": "hide", "threads": [thread.id]},
+    )
+    assert_contains(response, "Hide threads")
+    assert_contains(response, "Reason for hiding")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-swap" value="outerHTML"'
+    )
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "hide",
+            "threads": [thread.id],
+            "confirm": "true",
+        },
+    )
+    assert response.status_code == 302
+    assert response["location"] == reverse("misago:thread-list")
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_executes_moderation_action_with_form_in_htmx(
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {"moderation": "hide", "threads": [thread.id]},
+        headers={"hx-request": "true"},
+    )
+    assert_contains(response, "Reason for hiding")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_contains(response, 'type="hidden" name="success-hx-swap" value="outerHTML"')
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "hide",
+            "threads": [thread.id],
+            "confirm": "true",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert_contains(response, thread.title)
+
+    thread.refresh_from_db()
+    assert thread.is_hidden
+
+
 @override_dynamic_settings(index_view="categories")
 def test_thread_list_view_executes_moderation_action_with_confirmation(
-    thread_factory, moderator_client, default_category
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
 ):
     thread = thread_factory(default_category)
 
@@ -163,7 +237,15 @@ def test_thread_list_view_executes_moderation_action_with_confirmation(
         {"moderation": "delete", "threads": [thread.id]},
     )
     assert_contains(response, "Delete threads")
-    assert_contains(response, "Are you sure you want to delete selected threads?")
+    assert_contains(response, "Are you sure you want to delete the selected threads?")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_not_contains(
+        response, 'type="hidden" name="success-hx-swap" value="outerHTML"'
+    )
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
 
     response = moderator_client.post(
         reverse("misago:thread-list"),
@@ -180,10 +262,9 @@ def test_thread_list_view_executes_moderation_action_with_confirmation(
         thread.refresh_from_db()
 
 
-@pytest.mark.xfail(reason="delete thread moderation action not yet implemented")
 @override_dynamic_settings(index_view="categories")
 def test_thread_list_view_executes_moderation_action_with_confirmation_in_htmx(
-    thread_factory, moderator_client, default_category
+    thread_factory, moderator_client, default_category, mock_synchronize_categories
 ):
     thread = thread_factory(default_category)
 
@@ -192,8 +273,13 @@ def test_thread_list_view_executes_moderation_action_with_confirmation_in_htmx(
         {"moderation": "delete", "threads": [thread.id]},
         headers={"hx-request": "true"},
     )
-    assert_contains(response, "Delete")
-    assert_contains(response, "Are you sure you want to delete selected threads?")
+    assert_contains(response, "Are you sure you want to delete the selected threads?")
+    assert_contains(response, f'type="hidden" name="threads" value="{thread.id}"')
+    assert_contains(
+        response, 'type="hidden" name="success-hx-target" value="#misago-htmx-root"'
+    )
+    assert_contains(response, 'type="hidden" name="success-hx-swap" value="outerHTML"')
+    assert_contains(response, 'type="hidden" name="confirm" value="true"')
 
     response = moderator_client.post(
         reverse("misago:thread-list"),
@@ -204,70 +290,159 @@ def test_thread_list_view_executes_moderation_action_with_confirmation_in_htmx(
         },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, thread.title)
+    assert response.status_code == 200
 
     with pytest.raises(Thread.DoesNotExist):
         thread.refresh_from_db()
 
 
-@pytest.mark.xfail(reason="move thread moderation action not yet implemented")
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_executes_moderation_action_with_form(
-    thread_factory, moderator_client, default_category, child_category
+def test_thread_list_view_moderation_doesnt_set_htmx_trigger_header(
+    thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
 
     response = moderator_client.post(
         reverse("misago:thread-list"),
-        {"moderation": "move", "threads": [thread.id]},
-    )
-    assert_contains(response, "Move threads")
-    assert_contains(response, "Move to")
-
-    response = moderator_client.post(
-        reverse("misago:thread-list"),
         {
-            "moderation": "move",
+            "moderation": "lock",
             "threads": [thread.id],
-            "moderation-category": child_category.id,
-            "confirm": "true",
         },
     )
     assert response.status_code == 302
-    assert response["location"] == reverse("misago:thread-list")
+    assert "hx-trigger" not in response
 
     thread.refresh_from_db()
-    assert thread.category == child_category
+    assert thread.is_locked
 
 
-@pytest.mark.xfail(reason="move thread moderation action not yet implemented")
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_executes_moderation_action_with_form_in_htmx(
-    thread_factory, moderator_client, default_category, child_category
+def test_thread_list_view_moderation_sets_htmx_trigger_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
 
     response = moderator_client.post(
         reverse("misago:thread-list"),
-        {"moderation": "move", "threads": [thread.id]},
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+        },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, "Move to")
+    assert response.status_code == 200
+    assert response["hx-trigger"] == "misago:afterModeration"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_moderation_doesnt_set_htmx_retarget_header_on_success(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-target": "#misago-htmx-root",
+        },
+    )
+    assert response.status_code == 302
+    assert "hx-retarget" not in response
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_moderation_sets_htmx_retarget_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-target": "#misago-htmx-root",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert response.status_code == 200
+    assert response["hx-retarget"] == "#misago-htmx-root"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_moderation_doesnt_set_htmx_reswap_header_on_success(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-swap": "outerHTML",
+        },
+    )
+    assert response.status_code == 302
+    assert "hx-reswap" not in response
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_moderation_sets_htmx_reswap_header_on_success_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
+
+    response = moderator_client.post(
+        reverse("misago:thread-list"),
+        {
+            "moderation": "lock",
+            "threads": [thread.id],
+            "success-hx-swap": "outerHTML",
+        },
+        headers={"hx-request": "true"},
+    )
+    assert response.status_code == 200
+    assert response["hx-reswap"] == "outerHTML"
+
+    thread.refresh_from_db()
+    assert thread.is_locked
+
+
+@override_dynamic_settings(index_view="categories")
+def test_thread_list_view_moderation_doesnt_set_htmx_headers_on_template_response_in_htmx(
+    thread_factory, moderator_client, default_category
+):
+    thread = thread_factory(default_category)
 
     response = moderator_client.post(
         reverse("misago:thread-list"),
         {
             "moderation": "move",
             "threads": [thread.id],
-            "moderation-category": child_category.id,
-            "confirm": "true",
+            "success-hx-target": "#misago-htmx-root",
+            "success-hx-swap": "outerHTML",
         },
         headers={"hx-request": "true"},
     )
-    assert_contains(response, thread.title)
-
-    thread.refresh_from_db()
-    assert thread.category == child_category
+    assert response.status_code == 200
+    assert "hx-trigger" not in response
+    assert "hx-retarget" not in response
+    assert "hx-reswap" not in response
 
 
 @override_dynamic_settings(index_view="categories")

--- a/misago/threads/tests/test_thread_list_view_moderation_actions.py
+++ b/misago/threads/tests/test_thread_list_view_moderation_actions.py
@@ -296,8 +296,8 @@ def test_thread_list_view_hide_moderation_action_hides_threads(
         reverse("misago:thread-list"),
         {"moderation": "hide", "threads": [thread.id]},
     )
-    assert_contains(response, "Reason for hiding")
     assert_contains(response, "Hide threads")
+    assert_contains(response, "Reason for hiding")
 
     response = moderator_client.post(
         reverse("misago:thread-list"),

--- a/misago/threads/tests/test_thread_list_view_moderation_actions.py
+++ b/misago/threads/tests/test_thread_list_view_moderation_actions.py
@@ -25,7 +25,7 @@ def mock_delete_duplicate_watched_threads(mocker):
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_everywhere_moderation_action_pins_unpinned_thread(
+def test_thread_list_view_pin_everywhere_threads_moderation_action_pins_unpinned_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -48,7 +48,7 @@ def test_thread_list_view_pin_everywhere_moderation_action_pins_unpinned_thread(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_everywhere_moderation_action_pins_pinned_category_thread(
+def test_thread_list_view_pin_everywhere_threads_moderation_action_pins_pinned_category_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.CATEGORY)
@@ -71,7 +71,7 @@ def test_thread_list_view_pin_everywhere_moderation_action_pins_pinned_category_
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_everywhere_moderation_action_validates_threads(
+def test_thread_list_view_pin_everywhere_threads_moderation_action_validates_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.EVERYWHERE)
@@ -86,7 +86,7 @@ def test_thread_list_view_pin_everywhere_moderation_action_validates_threads(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_category_moderation_action_pins_unpinned_thread(
+def test_thread_list_view_pin_category_threads_moderation_action_pins_unpinned_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -109,7 +109,7 @@ def test_thread_list_view_pin_category_moderation_action_pins_unpinned_thread(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_category_moderation_action_pins_pinned_everywhere_thread(
+def test_thread_list_view_pin_category_threads_moderation_action_pins_pinned_everywhere_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.EVERYWHERE)
@@ -132,7 +132,7 @@ def test_thread_list_view_pin_category_moderation_action_pins_pinned_everywhere_
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_pin_category_moderation_action_validates_threads(
+def test_thread_list_view_pin_category_threads_moderation_action_validates_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.CATEGORY)
@@ -147,7 +147,7 @@ def test_thread_list_view_pin_category_moderation_action_validates_threads(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_unpin_moderation_action_unpins_pinned_everywhere_thread(
+def test_thread_list_view_unpin_threads_moderation_action_unpins_pinned_everywhere_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.EVERYWHERE)
@@ -170,7 +170,7 @@ def test_thread_list_view_unpin_moderation_action_unpins_pinned_everywhere_threa
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_unpin_moderation_action_unpins_pinned_category_thread(
+def test_thread_list_view_unpin_threads_moderation_action_unpins_pinned_category_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, pinned=ThreadPinned.CATEGORY)
@@ -208,7 +208,7 @@ def test_thread_list_view_unpin_moderation_action_validates_threads(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_lock_moderation_action_locks_thread(
+def test_thread_list_view_lock_moderation_action_locks_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category)
@@ -245,7 +245,7 @@ def test_thread_list_view_lock_moderation_action_validates_threads(
 
 
 @override_dynamic_settings(index_view="categories")
-def test_thread_list_view_unlock_moderation_action_unlocks_thread(
+def test_thread_list_view_unlock_moderation_action_unlocks_threads(
     thread_factory, moderator_client, default_category
 ):
     thread = thread_factory(default_category, is_locked=True)


### PR DESCRIPTION
Part of the #1789 epic

# TODO

- [x] Test hidden fields in thread list moderation views
- [x] Test hx-headers handling in thread list moderation
- [x] Unify test case names to `test_thread_detail_view_lock_thread_moderation_action_locks_thread`