### PR TITLE
Fix aria-invalid on invalid form fields

### DIFF
--- a/frontend/src/components/form-group.js
+++ b/frontend/src/components/form-group.js
@@ -54,6 +54,16 @@ export default class extends React.Component {
     }
   }
 
+  getControl() {
+    if (this.props.validation) {
+      return React.cloneElement(this.props.children, {
+        "aria-invalid": "true",
+      })
+    }
+
+    return this.props.children
+  }
+
   render() {
     return (
       <div className={this.getClassName()}>
@@ -64,7 +74,7 @@ export default class extends React.Component {
           {this.props.label + ":"}
         </label>
         <div className={this.props.controlClass || ""}>
-          {this.props.children}
+          {this.getControl()}
           {this.getFeedbackDescription()}
           {this.getFeedback()}
           {this.getHelpText()}


### PR DESCRIPTION
Description

Fixes the accessibility issue by adding aria-invalid="true" to form controls when validation errors are present.

Changes
Added handling in FormGroup to set aria-invalid="true" on invalid form controls.
Valid or unvalidated controls are left unchanged.

Testing
Tested the registration form with an invalid password.
Confirmed that the validation error is displayed.
Confirmed through browser inspection that the invalid input contains aria-invalid="true".